### PR TITLE
chore: bump rc.6 and refresh website hero

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparkling",
-  "version": "2.0.0-rc.5",
+  "version": "2.0.0-rc.6",
   "description": "Sparkling is the mobile cross-platform development infrastructure for TikTok App.",
   "homepage": "",
   "repository": {

--- a/packages/sparkling-method/package.json
+++ b/packages/sparkling-method/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparkling-method",
-  "version": "2.0.0-rc.5",
+  "version": "2.0.0-rc.6",
   "homepage": "",
   "repository": {
     "type": "git",

--- a/packages/sparkling-sdk/package.json
+++ b/packages/sparkling-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparkling-sdk",
-  "version": "2.0.0-rc.5",
+  "version": "2.0.0-rc.6",
   "license": "Apache-2.0",
   "description": "Android & iOS SDK for Sparkling Framework",
   "homepage": "",

--- a/packages/website/docs/en/index.mdx
+++ b/packages/website/docs/en/index.mdx
@@ -5,9 +5,9 @@ description: Cross platform infrastructure of TikTok mobile app
 hero:
   name: Sparkling Version 2.0.0
   text: |-
-    Cross-platform Infrastructure
-    Used by TikTok
-  tagline: An out-of-the-box cross-platform framework for mobile apps.
+    Unlocks Lynx at TikTok Scale
+  tagline: |-
+    The cross-platform infrastructure behind TikTok
   actions:
     - text: Get Started
       link: /guide/get-started/create-new-app
@@ -17,23 +17,28 @@ hero:
       theme: alt
 features:
   - icon: /icons/icon-high-performance.svg
-    title: High-performance rendering
-    details: Powered by Lynx with optimized container lifecycle.
-  - icon: /icons/icon-js-native-bridge.svg
-    title: JS ↔ Native communication pipe
-    details: Sparkling Method provides codegen, validation, and parity across platforms.
-  - icon: /icons/icon-modular-native.svg
-    title: Modular built‑in Native Abilities
-    details: Router, storage, media and more can be autolinked in minutes.
-  - icon: /icons/icon-android-ios.svg
-    title: Android & iOS ready
-    details: One Lynx bundle works across both native shells.
-  - icon: /icons/icon-multi-page.svg
-    title: Multi-page Lynx App support
-    details: Build multi-page Lynx apps with route-based entrypoints and scalable structure.
+    title: Built for Lynx
+    details: "Deeply optimized for Lynx's performance: native rendering, instant first render."
+
   - icon: /icons/icon-lynx-ecosystem.svg
-    title: Full compatibility with the Lynx ecosystem
-    details: Seamlessly integrate with Lynx tooling, components, and existing app infrastructure.
+    title: Built for Brownfield
+    details: Works with your existing infrastructure. Adopt Lynx incrementally, at your own pace.
+
+  - icon: /icons/icon-android-ios.svg
+    title: Android & iOS
+    details: One Lynx bundle, both platforms. Scaffold and run with a single CLI command.
+
+  - icon: /icons/icon-multi-page.svg
+    title: Multi-page Navigation
+    details: Scheme-driven routing with per-page entrypoints, built for large-scale apps.
+
+  - icon: /icons/icon-js-native-bridge.svg
+    title: Sparkling Method
+    details: Type-safe JS ↔ Native bridge with codegen and cross-platform parity.
+
+  - icon: /icons/icon-modular-native.svg
+    title: Modular Native APIs
+    details: "Router, storage, media and more — npm install and autolinked."
 ---
 
 ## What is Sparkling?

--- a/packages/website/docs/zh/index.mdx
+++ b/packages/website/docs/zh/index.mdx
@@ -6,7 +6,8 @@ hero:
   name: Sparkling Version 2.0.0
   text: |-
     TikTok 跨端基础设施
-  tagline: 开箱即用的移动应用跨平台开发框架
+  tagline: |-
+    TikTok 同款跨端基建，释放 Lynx 潜力
   actions:
     - text: 快速开始
       link: /guide/get-started/create-new-app
@@ -16,23 +17,28 @@ hero:
       theme: alt
 features:
   - icon: /icons/icon-high-performance.svg
-    title: 高性能渲染
-    details: 基于 Lynx 的跨平台混合容器
-  - icon: /icons/icon-js-native-bridge.svg
-    title: JS 与 Native 通信桥接
-    details: Sparkling Method 提供跨平台一致的 codegen 与校验。
-  - icon: /icons/icon-modular-native.svg
-    title: 模块化内置 Methods
-    details: Router、Storage、Media 等可快速 autolink。
-  - icon: /icons/icon-android-ios.svg
-    title: Android & iOS 支持
-    details: 同一份 Lynx bundle 同时运行在两端原生壳内。
-  - icon: /icons/icon-multi-page.svg
-    title: 多页面 Lynx 应用支持
-    details: 支持多页面 Lynx 应用形态，按路由组织入口，便于规模化扩展。
+    title: 为 Lynx 而生
+    details: 深度适配 Lynx 的性能优势：原生渲染、首帧直出。
+
   - icon: /icons/icon-lynx-ecosystem.svg
-    title: 与 Lynx 生态的完全兼容
-    details: 与 Lynx 生态工具链、组件体系和既有基础设施无缝衔接。
+    title: 为大型应用而生
+    details: 与既有基建无缝协作，按你的节奏逐步引入 Lynx。
+
+  - icon: /icons/icon-android-ios.svg
+    title: Android & iOS 双端支持
+    details: 一份 Lynx 产物，两个平台。一条 CLI 命令创建并运行。
+
+  - icon: /icons/icon-multi-page.svg
+    title: 多页面导航
+    details: 基于 URL Scheme 的路由，支持按页面独立入口，适配大型应用。
+
+  - icon: /icons/icon-js-native-bridge.svg
+    title: Sparkling Method
+    details: 类型安全的 JS ↔ Native 桥接，支持 codegen 和跨平台一致性。
+
+  - icon: /icons/icon-modular-native.svg
+    title: 开箱即用的 Native API
+    details: 路由、存储、媒体等能力，npm install 即可 autolink 使用。
 ---
 
 ## Sparkling 是什么？

--- a/packages/website/package-lock.json
+++ b/packages/website/package-lock.json
@@ -8,7 +8,9 @@
       "name": "sparkling-website",
       "version": "0.0.0",
       "devDependencies": {
-        "@rspress/core": "^2.0.2"
+        "@rspack/core": "2.0.0-alpha.1",
+        "@rspress/core": "^2.0.2",
+        "playwright": "^1.58.2"
       },
       "engines": {
         "node": ">=20"
@@ -3008,6 +3010,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/property-information": {

--- a/packages/website/rspress.config.ts
+++ b/packages/website/rspress.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from '@rspress/core';
-import path from 'node:path';
 import { createRequire } from 'node:module';
+import path from 'node:path';
 
 const require = createRequire(import.meta.url);
 const rootPkg = require('../../package.json');
@@ -24,7 +24,7 @@ const navEn = [
 
 const navZh = [
   { text: '指南', link: '/guide/get-started/create-new-app' },
-  { text: '接口', link: '/apis/sparkling-sdk-android' },
+  { text: 'APIs', link: '/apis/sparkling-sdk-android' },
 ];
 
 // ---------------------------------------------------------------------------
@@ -37,13 +37,13 @@ const sidebarEn = {
     {
       text: 'Get Started',
       items: [
-        { text: 'Create New App', link: '/guide/get-started/create-new-app' },
+        { text: 'Create a New App', link: '/guide/get-started/create-new-app' },
         {
-          text: 'Integrate Sparkling into Existing App',
+          text: 'Integrate into Existing App',
           link: '/guide/get-started/integrate-sparkling-into-existing-app',
         },
         {
-          text: 'Create Custom Method',
+          text: 'Create a Custom Method',
           link: '/guide/get-started/create-custom-method',
         },
       ],

--- a/packages/website/theme/index.tsx
+++ b/packages/website/theme/index.tsx
@@ -18,7 +18,15 @@ function HomeLayout() {
   useEffect(() => {
     const brand = document.querySelector('.rp-home-hero__title-brand');
     if (brand) {
-      brand.textContent = `Sparkling Version ${__SPARKLING_VERSION__}`;
+      (brand as HTMLElement).innerHTML = `
+        <a
+          href="https://github.com/tiktok/sparkling/releases"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Sparkling Version ${__SPARKLING_VERSION__}
+        </a>
+      `;
     }
   }, []);
 


### PR DESCRIPTION
## Summary
- Bump root, method, and SDK packages from 2.0.0-rc.5 to 2.0.0-rc.6.
- Refresh EN/ZH homepage hero copy and feature list to emphasize Lynx and large-scale/brownfield adoption.
- Update website nav label, make hero title link to GitHub releases, and add @rspack/core + Playwright devDependencies.



