### PR TITLE
[Bugfix][iOS] set minimum Ruby version to 2.7.0 to resolve dependency conflicts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
-gem "cocoapods", "~> 1.16.2"
+ruby '>= 2.7.5'
+gem 'cocoapods', '>= 1.14'
+gem "ffi", "1.16.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,28 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.9)
-    activesupport (6.1.7.10)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+    CFPropertyList (3.0.8)
+    activesupport (7.2.3)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
       minitest (>= 5.1)
-      tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.8.8)
       public_suffix (>= 2.0.2, < 8.0)
     algoliasearch (1.27.5)
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
     atomos (0.1.3)
+    base64 (0.3.0)
+    benchmark (0.5.0)
+    bigdecimal (4.0.1)
     claide (1.1.0)
     cocoapods (1.16.2)
       addressable (~> 2.8)
@@ -54,11 +63,12 @@ GEM
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
     concurrent-ruby (1.3.6)
+    connection_pool (3.0.2)
+    drb (2.2.3)
     escape (0.0.4)
     ethon (0.15.0)
       ffi (>= 1.15.0)
-    ffi (1.17.2-arm64-darwin)
-    ffi (1.17.2-x86_64-darwin)
+    ffi (1.16.3)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
@@ -67,15 +77,19 @@ GEM
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     json (2.7.6)
-    minitest (5.25.4)
+    logger (1.7.0)
+    minitest (6.0.1)
+      prism (~> 1.5)
     molinillo (0.8.0)
     mutex_m (0.3.0)
     nanaimo (0.4.0)
     nap (1.1.0)
     netrc (0.11.0)
+    prism (1.9.0)
     public_suffix (4.0.7)
     rexml (3.4.4)
     ruby-macho (2.5.1)
+    securerandom (0.4.1)
     typhoeus (1.5.0)
       ethon (>= 0.9.0, < 0.16.0)
     tzinfo (2.0.6)
@@ -87,7 +101,6 @@ GEM
       colored2 (~> 3.1)
       nanaimo (~> 0.4.0)
       rexml (>= 3.3.6, < 4.0)
-    zeitwerk (2.6.18)
 
 PLATFORMS
   arm64-darwin-23
@@ -96,7 +109,9 @@ PLATFORMS
   x86_64-darwin
 
 DEPENDENCIES
-  cocoapods (~> 1.16.2)
+  cocoapods (>= 1.14)
+  ffi (= 1.16.3)
+
 
 BUNDLED WITH
    2.3.27

--- a/docs/en/guide/cli.md
+++ b/docs/en/guide/cli.md
@@ -127,6 +127,7 @@ The doctor command checks:
 | JDK | Version >= 11 (Android) |
 | Android SDK | `ANDROID_HOME` set, `android-34` installed |
 | adb | Available in PATH |
+| Ruby | Version >= 2.7, < 3.4 |
 | Xcode | Version >= 16 (macOS only) |
 | CocoaPods | Installed (macOS only) |
 | iOS Simulator | At least one available (macOS only) |

--- a/docs/en/guide/get-started/create-new-app.md
+++ b/docs/en/guide/get-started/create-new-app.md
@@ -58,3 +58,4 @@ Key folders/files created by the default template:
 - For running native shells:
   - Android Studio / Android SDK (Android) / JDK 11
   - Xcode 16+ + iOS Simulator (iOS)
+  - Ruby (>=2.7, <3.4) for iOS build

--- a/docs/zh/guide/cli.md
+++ b/docs/zh/guide/cli.md
@@ -127,6 +127,7 @@ doctor 命令检查的内容：
 | JDK | 版本 >= 11（Android） |
 | Android SDK | 已设置 `ANDROID_HOME`，已安装 `android-34` |
 | adb | 在 PATH 中可用 |
+| Ruby | 版本 >= 2.7, < 3.4 |
 | Xcode | 版本 >= 16（仅 macOS） |
 | CocoaPods | 已安装（仅 macOS） |
 | iOS 模拟器 | 至少有一个可用（仅 macOS） |

--- a/packages/sparkling-app-cli/src/commands/run-ios.ts
+++ b/packages/sparkling-app-cli/src/commands/run-ios.ts
@@ -188,7 +188,7 @@ async function installPods(podfilePath: string): Promise<void> {
   }
 
   try {
-    const env = { ...(gemfile ? { BUNDLE_GEMFILE: gemfile } : {}), RUBYOPT: '-rlogger' };
+    const env = { ...(gemfile ? { BUNDLE_GEMFILE: gemfile } : {}) };
     await runCommand('bundle', ['exec', 'pod', 'install'], { cwd: podDir, env });
   } catch (error) {
     throw new Error(

--- a/template/sparkling-app-template/Gemfile
+++ b/template/sparkling-app-template/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-ruby '>= 2.6.10'
-
+ruby '>= 2.7.5'
 gem 'cocoapods', '>= 1.14'
+gem "ffi", "1.16.3"

--- a/template/sparkling-app-template/Gemfile.lock
+++ b/template/sparkling-app-template/Gemfile.lock
@@ -1,19 +1,28 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.9)
-    activesupport (6.1.7.10)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+    CFPropertyList (3.0.8)
+    activesupport (7.2.3)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
       minitest (>= 5.1)
-      tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.8.8)
       public_suffix (>= 2.0.2, < 8.0)
     algoliasearch (1.27.5)
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
     atomos (0.1.3)
+    base64 (0.3.0)
+    benchmark (0.5.0)
+    bigdecimal (4.0.1)
     claide (1.1.0)
     cocoapods (1.16.2)
       addressable (~> 2.8)
@@ -53,28 +62,34 @@ GEM
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.3.5)
+    concurrent-ruby (1.3.6)
+    connection_pool (3.0.2)
+    drb (2.2.3)
     escape (0.0.4)
     ethon (0.15.0)
       ffi (>= 1.15.0)
-    ffi (1.17.2-arm64-darwin)
+    ffi (1.16.3)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
     httpclient (2.9.0)
       mutex_m
-    i18n (1.14.7)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     json (2.7.6)
-    minitest (5.25.4)
+    logger (1.7.0)
+    minitest (6.0.1)
+      prism (~> 1.5)
     molinillo (0.8.0)
     mutex_m (0.3.0)
     nanaimo (0.4.0)
     nap (1.1.0)
     netrc (0.11.0)
+    prism (1.9.0)
     public_suffix (4.0.7)
     rexml (3.4.4)
     ruby-macho (2.5.1)
+    securerandom (0.4.1)
     typhoeus (1.5.0)
       ethon (>= 0.9.0, < 0.16.0)
     tzinfo (2.0.6)
@@ -86,14 +101,17 @@ GEM
       colored2 (~> 3.1)
       nanaimo (~> 0.4.0)
       rexml (>= 3.3.6, < 4.0)
-    zeitwerk (2.6.18)
 
 PLATFORMS
   arm64-darwin-23
+  arm64-darwin-24
   arm64-darwin-25
+  x86_64-darwin
 
 DEPENDENCIES
-  cocoapods (~> 1.16.2)
+  cocoapods (>= 1.14)
+  ffi (= 1.16.3)
+
 
 BUNDLED WITH
    2.3.27


### PR DESCRIPTION
## Summary
This PR fixes dependency conflict issues on certain platforms by setting the minimum required Ruby version to ≥ 2.7.0 in the Ruby build configuration. This ensures that the project’s Ruby dependencies (e.g., CocoaPods and related gems) resolve correctly without version mismatches during install or build steps. 

## Related issues
#9 

## Changes
- Updated Gemfile to require ruby '>= 2.7.5' and loosened version constraint on CocoaPods.  ￼
- Regenerated Gemfile.lock with updated dependency graph to match new Ruby requirement.  ￼
- Updated documentation (docs/.../cli.md, get-started/create-new-app.md) to include new Ruby version guidance.  ￼
- Remove `-rlogger` when doing `pod install` in CLI code.

## How to test
```shell
# create new app using sparkling cli.
npm create sparkling-app@latest my-app

# enter demo app directory
cd my-app

# run run:ios to check if it works.
npm run run:ios

```

## Checklist
- [x] I read `CONTRIBUTING.md`.
- [x] I linked a related issue (or explained why this is standalone).
- [x] I ran relevant checks
- [x] I updated docs/examples (if needed).
- [x] I added/updated tests (if applicable), or explained why not.

