### PR TITLE
fix(ios): add network fallback for HTTP image loading

### DIFF
--- a/packages/sparkling-app-cli/src/commands/dev.ts
+++ b/packages/sparkling-app-cli/src/commands/dev.ts
@@ -1,10 +1,11 @@
 // Copyright (c) 2026 TikTok Pte. Ltd.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+import fs from 'node:fs';
 import path from 'node:path';
-import { createDevLynxConfig } from '../config';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { createDevLynxConfig, loadAppConfig } from '../config';
 import { DEV_SERVER_PORT } from '../constants';
-import { runCommand } from '../utils/exec';
 import { ui } from '../utils/ui';
 import { isVerboseEnabled, verboseLog } from '../utils/verbose';
 
@@ -14,17 +15,117 @@ export interface DevOptions {
   port?: number;
 }
 
+function getEntryKeys(config: { lynxConfig: unknown }): string[] {
+  const lynxConfig = config.lynxConfig as Record<string, unknown>;
+  const source = lynxConfig?.source as Record<string, unknown> | undefined;
+  const entry = source?.entry;
+  if (!entry || typeof entry !== 'object') return [];
+  return Object.keys(entry).sort();
+}
+
+/**
+ * Clear require cache for the app config so loadAppConfig picks up fresh content.
+ */
+function clearConfigRequireCache(cwd: string, configPath: string): void {
+  const resolvedConfig = path.resolve(configPath);
+  const tempLoader = path.resolve(cwd, '.sparkling', 'app.config.cjs');
+  delete require.cache[resolvedConfig];
+  delete require.cache[tempLoader];
+}
+
 export async function devProject(options: DevOptions): Promise<void> {
-  const configPath = path.resolve(options.cwd, options.configFile ?? 'app.config.ts');
+  const configFile = options.configFile ?? 'app.config.ts';
+  const configPath = path.resolve(options.cwd, configFile);
   const port = options.port ?? DEV_SERVER_PORT;
-  const tempConfigPath = createDevLynxConfig(options.cwd, configPath, port);
 
   if (isVerboseEnabled()) {
     verboseLog(`App config path: ${configPath}`);
-    verboseLog(`Temp Lynx config: ${tempConfigPath}`);
     verboseLog(`Dev server port: ${port}`);
   }
 
-  console.log(ui.headline(`Starting Rspeedy dev server on port ${port} with config from ${path.relative(options.cwd, configPath)}`));
-  await runCommand('rspeedy', ['dev', '--config', tempConfigPath], { cwd: options.cwd });
+  // Load initial config to track entry keys
+  let currentEntryKeys: string[];
+  try {
+    const { config } = await loadAppConfig(options.cwd, configFile);
+    currentEntryKeys = getEntryKeys(config);
+  } catch {
+    currentEntryKeys = [];
+  }
+
+  console.log(
+    ui.headline(
+      `Starting Rspeedy dev server on port ${port} with config from ${path.relative(options.cwd, configPath)}`,
+    ),
+  );
+
+  let restarting = false;
+  let child: ChildProcess | null = null;
+
+  // Watch app.config.ts for entry changes and restart Rspeedy when needed
+  let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+  const watcher = fs.watch(configPath, () => {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(async () => {
+      try {
+        clearConfigRequireCache(options.cwd, configPath);
+        const { config: newConfig } = await loadAppConfig(options.cwd, configFile);
+        const newEntryKeys = getEntryKeys(newConfig);
+
+        if (
+          newEntryKeys.length === currentEntryKeys.length
+          && newEntryKeys.every((key, i) => key === currentEntryKeys[i])
+        ) {
+          if (isVerboseEnabled()) {
+            verboseLog('app.config.ts changed but entries unchanged, skipping restart');
+          }
+          return;
+        }
+
+        console.log(
+          ui.headline('Detected entry change in app.config.ts, restarting dev server...'),
+        );
+        currentEntryKeys = newEntryKeys;
+        restarting = true;
+        if (child) {
+          child.kill('SIGTERM');
+        }
+      } catch (err) {
+        if (isVerboseEnabled()) {
+          verboseLog(`Failed to reload app.config.ts: ${err}`);
+        }
+      }
+    }, 300);
+  });
+
+  try {
+    // Main loop: spawn Rspeedy, restart on entry changes
+    while (true) {
+      const tempConfigPath = createDevLynxConfig(options.cwd, configPath, port);
+      child = spawn('rspeedy', ['dev', '--config', tempConfigPath], {
+        cwd: options.cwd,
+        env: process.env,
+        stdio: 'inherit',
+        shell: false,
+      });
+
+      await new Promise<void>((resolve, reject) => {
+        child!.on('error', reject);
+        child!.on('close', (code) => {
+          if (restarting) {
+            resolve();
+          } else if (code) {
+            reject(new Error(`rspeedy exited with code ${code}`));
+          } else {
+            resolve();
+          }
+        });
+      });
+
+      if (!restarting) break;
+      restarting = false;
+    }
+  } finally {
+    watcher.close();
+    if (debounceTimer) clearTimeout(debounceTimer);
+  }
 }

--- a/packages/sparkling-sdk/ios/Sparkling/Application/Container/Resource/SPKResourceLoaderImpl.swift
+++ b/packages/sparkling-sdk/ios/Sparkling/Application/Container/Resource/SPKResourceLoaderImpl.swift
@@ -92,14 +92,14 @@ open class SPKResourceLoaderImpl: NSObject, SPKResourceLoaderProtocol {
         guard let url = url else {
             return nil
         }
-        
+
         let bundleURL: URL?
         if url.scheme == "asset" {
             bundleURL = URL.spk.url(string: ".\(url.path)")
         } else {
             bundleURL = url
         }
-        
+
         if let bundleURL = bundleURL,
            let result = self.loadBundleResource(withURL: bundleURL),
            let data = result.resourceData {
@@ -110,7 +110,21 @@ open class SPKResourceLoaderImpl: NSObject, SPKResourceLoaderProtocol {
             }
             return nil
         }
-        
+
+        // Network fallback for HTTP(S) URLs (e.g. dev server assets)
+        if let scheme = url.scheme?.lowercased(), scheme == "http" || scheme == "https" {
+            let request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: 10)
+            let task = URLSession.shared.dataTask(with: request) { data, _, error in
+                if let data = data, error == nil, let image = UIImage(data: data) {
+                    completion(image, nil)
+                } else {
+                    completion(nil, error)
+                }
+            }
+            task.resume()
+            return task
+        }
+
         return nil
     }
     


### PR DESCRIPTION
## Summary
- `SPKResourceLoaderImpl.loadImage()` only loaded from the local bundle and **returned nil for HTTP URLs** without attempting a network request
- In dev mode, Rspeedy serves assets from `http://<ip>:5969/static/image/...` — images silently failed to load
- Add `URLSession` network fallback for HTTP(S) URLs, matching the existing pattern in `loadResource()`

**Stacked on #42**

## Test plan
- [ ] Run a Sparkling app with `pnpm dev` (dev server mode)
- [ ] Verify `<image src={require('./icon.png')}>` loads correctly (image URL resolves to dev server HTTP URL)
- [ ] Verify production build still loads images from `asset:///` correctly