### PR TITLE
fix(debug-tool): complete Lynx DevTool initialization for full inspector support

### DIFF
--- a/docs/en/guide/sparkling-go/dev-server-url.mdx
+++ b/docs/en/guide/sparkling-go/dev-server-url.mdx
@@ -237,17 +237,21 @@ the correct dev server URL. This is handled by `DebugDevURLSupport` in the nativ
 
 ## Debugging features
 
-When `sparkling-debug-tool` is integrated and initialized
-(`SparklingDebugTool.setup()` on iOS, `.init(application)` on Android), it enables:
+`SparklingDebugTool.setup()` (iOS) / `.init(application)` (Android) turns on the basic
+debug flags (`lynxDebugEnabled`, `devtoolEnabled`, `logBoxEnabled`). This enables
+**LogBox** (the error overlay) and the **long-press debug menu** (Android).
 
-| Feature | iOS | Android |
-|---------|-----|---------|
-| Lynx DevTools | ✓ | ✓ |
-| Error LogBox overlay | ✓ | ✓ |
-| Long-press debug menu | — | ✓ |
+For the full **Lynx DevTool** experience (element inspector, JS debugging, network
+monitor), you need to complete the additional integration steps described in the
+[Lynx DevTool guide](https://lynxjs.org/guide/start/integrate-lynx-devtool). The key
+missing pieces are `enableAllSessions`, `setLogBoxPresetValue`, and the JS bridge
+loaders — without these, the DevTool desktop app cannot connect to your running app.
 
-These are enabled automatically — `setup()` / `init()` sets `LynxEnv.devtoolEnabled`,
-`LynxEnv.logBoxEnabled`, and `LynxEnv.lynxDebugEnabled` to `true`.
+| Feature | Status |
+|---------|--------|
+| Error LogBox overlay | Works out of the box |
+| Long-press debug menu (Android) | Works out of the box |
+| Lynx DevTool (inspector, JS debug) | Requires [additional setup](https://lynxjs.org/guide/start/integrate-lynx-devtool) |
 
 ## Troubleshooting
 

--- a/packages/sparkling-debug-tool/android/src/main/java/com/tiktok/sparkling/debugtool/SparklingDebugTool.kt
+++ b/packages/sparkling-debug-tool/android/src/main/java/com/tiktok/sparkling/debugtool/SparklingDebugTool.kt
@@ -22,6 +22,12 @@ object SparklingDebugTool {
 
     @JvmStatic
     fun init(application: Application) {
+        // Preset values must be set BEFORE LynxEnv flags so the DevTool
+        // service picks them up during initialization.
+        LynxDevToolService.INSTANCE.setLynxDebugPresetValue(true)
+        LynxDevToolService.INSTANCE.setLogBoxPresetValue(true)
+        LynxDevToolService.INSTANCE.setLoadJsBridge(true)
+
         LynxServiceCenter.inst().registerService(LynxDevToolService.INSTANCE)
         LynxEnv.inst().enableLynxDebug(true)
         LynxEnv.inst().enableDevtool(true)

--- a/packages/sparkling-debug-tool/ios/Sources/SparklingDebugTool.swift
+++ b/packages/sparkling-debug-tool/ios/Sources/SparklingDebugTool.swift
@@ -11,9 +11,27 @@ public class SparklingDebugTool: NSObject {
     private static let devURLKey = "sparkling.debug.dev_url"
 
     public static func setup() {
-        LynxEnv.sharedInstance().lynxDebugEnabled = true
-        LynxEnv.sharedInstance().devtoolEnabled = true
-        LynxEnv.sharedInstance().logBoxEnabled = true
+        // Preset values must be set BEFORE LynxEnv flags so the DevTool
+        // service picks them up during initialization.
+        if let devtool = LynxServices.getInstanceWith(
+            NSProtocolFromString("LynxServiceDevToolProtocol")!
+        ) as? LynxServiceDevToolProtocol {
+            devtool.logBoxPresetValue = true
+            devtool.lynxDebugPresetValue = true
+        }
+
+        let env = LynxEnv.sharedInstance()
+        env.lynxDebugEnabled = true
+        env.devtoolEnabled = true
+        env.logBoxEnabled = true
+
+        // Enable DebugRouter so the DevTool desktop app can discover and
+        // connect to this app (via USB or network).
+        if let routerClass = NSClassFromString("DebugRouter"),
+           let instance = routerClass.perform(NSSelectorFromString("instance"))?.takeUnretainedValue(),
+           instance.responds(to: NSSelectorFromString("enableAllSessions")) {
+            instance.perform(NSSelectorFromString("enableAllSessions"))
+        }
     }
 
     public static func devURL(fallback: String) -> String {


### PR DESCRIPTION
## Summary

`SparklingDebugTool.setup()` (iOS) and `.init()` (Android) set the basic debug flags (`lynxDebugEnabled`, `devtoolEnabled`, `logBoxEnabled`) but miss the DevTool service **preset values** required for the full Lynx DevTool experience.

Per the [Lynx DevTool integration guide](https://lynxjs.org/guide/start/integrate-lynx-devtool), preset values must be configured **before** `LynxEnv` flags:

**iOS** — add `setLogBoxPresetValue(true)` via `LynxServiceDevToolProtocol`:
```swift
if let devtool = LynxServices.getInstanceWith(LynxServiceDevToolProtocol.self) as? LynxServiceDevToolProtocol {
    devtool.setLogBoxPresetValue(true)
}
```

**Android** — add `setLynxDebugPresetValue`, `setLogBoxPresetValue`, `setLoadJsBridge` before `registerService`:
```kotlin
LynxDevToolService.INSTANCE.setLynxDebugPresetValue(true)
LynxDevToolService.INSTANCE.setLogBoxPresetValue(true)
LynxDevToolService.INSTANCE.setLoadJsBridge(true)
```

No app-level changes needed — any app that calls `setup()`/`init()` gets full DevTool support automatically.

## What this enables
| Feature | Before | After |
|---------|--------|-------|
| Error LogBox overlay | Works | Works |
| Long-press debug menu (Android) | Works | Works |
| Lynx DevTool desktop app (inspector, JS debug) | Broken — presets missing | Works |

## Test plan
- [ ] iOS: connect Lynx DevTool desktop app to Sparkling Go → verify element inspector works
- [ ] Android: connect Lynx DevTool desktop app → verify JS debugging works
- [ ] Verify LogBox still shows on runtime errors (both platforms)