### PR TITLE
docs: add containers to sidebar, cross-reference core guide pages

### DIFF
--- a/docs/en/guide/containers.md
+++ b/docs/en/guide/containers.md
@@ -175,9 +175,9 @@ spkView.update(withGlobalProps: ["theme": "dark"])
 spkView?.updateGlobalPropsByIncrement(mapOf("theme" to "dark"))
 ```
 
-## API reference
+## Next steps
 
-For platform-specific installation, initialization, and detailed method signatures:
-
-- [Sparkling SDK — iOS](../apis/sparkling-sdk-ios.md)
-- [Sparkling SDK — Android](../apis/sparkling-sdk-android.md)
+- [Scheme](./scheme.md) — full list of URL parameters for configuring containers
+- [Multi-page Navigation](./multi-page-navigation.md) — navigate between pages, pass data, close pages
+- [Sparkling SDK — iOS](../apis/sparkling-sdk-ios.md) — iOS API reference
+- [Sparkling SDK — Android](../apis/sparkling-sdk-android.md) — Android API reference

--- a/docs/en/guide/multi-page-navigation.md
+++ b/docs/en/guide/multi-page-navigation.md
@@ -1,6 +1,6 @@
 # Multi-page Navigation
 
-Sparkling uses a native container model where each page runs as an independent native container with its own LynxView. Navigation between pages is driven by scheme URLs.
+Sparkling uses a native [container](./containers.md) model where each page runs as an independent native container with its own LynxView. Navigation between pages is driven by [scheme URLs](./scheme.md).
 
 Every entry you define in `source.entry` of your build config — whether that's the `lynxConfig` inside `app.config.ts` or a standalone `lynx.config.ts` — produces a bundle that can be navigated to. There is no route registration step: once a bundle is built, any page can navigate to it by its bundle path using the `navigate()` function.
 
@@ -8,8 +8,8 @@ Every entry you define in `source.entry` of your build config — whether that's
 
 When you call `navigate()`, Sparkling:
 
-1. Builds a scheme URL (e.g. `hybrid://lynxview_page?bundle=detail.lynx.bundle&title=Detail`)
-2. Hands the URL to the native layer, which opens a new container
+1. Builds a [scheme URL](./scheme.md) (e.g. `hybrid://lynxview_page?bundle=detail.lynx.bundle&title=Detail`)
+2. Hands the URL to the native layer, which opens a new [container](./containers.md)
 3. The new container loads the target bundle and receives the URL's query parameters via `lynx.__globalProps.queryItems`
 
 ## Basic navigation
@@ -34,7 +34,7 @@ navigate(
 );
 ```
 
-The `params` object supports all predefined keys (`title`, `hide_nav_bar`, `screen_orientation`, etc.) as well as arbitrary custom keys.
+The `params` object supports all [predefined scheme parameters](./scheme.md#common-parameters) (`title`, `hide_nav_bar`, `screen_orientation`, etc.) as well as arbitrary custom keys.
 
 ## Passing custom data
 

--- a/docs/en/guide/scheme.md
+++ b/docs/en/guide/scheme.md
@@ -26,6 +26,8 @@ protocol     host                        query parameters
 
 ## Container types (hosts)
 
+The host determines which native container is used to render the content. See [Containers](./containers.md) for details on each container mode.
+
 | Host | Description |
 | --- | --- |
 | `lynxview_page` | Lynx page container (recommended) |
@@ -55,7 +57,7 @@ For the full parameter reference, see the [Scheme API doc](/apis/scheme).
 
 ## Usage from JS
 
-You rarely need to construct scheme URLs by hand. The [`navigate()`](/apis/sparkling-methods/sparkling-navigation) function builds them for you:
+You rarely need to construct scheme URLs by hand. The [`navigate()`](/apis/sparkling-methods/sparkling-navigation) function builds them for you. See [Multi-page Navigation](./multi-page-navigation.md) for common navigation patterns (passing data, closing pages, etc.).
 
 ```ts
 import { navigate } from 'sparkling-navigation';

--- a/docs/zh/guide/containers.md
+++ b/docs/zh/guide/containers.md
@@ -175,9 +175,9 @@ spkView.update(withGlobalProps: ["theme": "dark"])
 spkView?.updateGlobalPropsByIncrement(mapOf("theme" to "dark"))
 ```
 
-## API 参考
+## 下一步
 
-平台相关的安装方式、初始化和详细方法签名：
-
-- [Sparkling SDK — iOS](../apis/sparkling-sdk-ios.md)
-- [Sparkling SDK — Android](../apis/sparkling-sdk-android.md)
+- [Scheme](./scheme.md) — 配置容器的完整 URL 参数列表
+- [多页面导航](./multi-page-navigation.md) — 页面间跳转、传递数据、关闭页面
+- [Sparkling SDK — iOS](../apis/sparkling-sdk-ios.md) — iOS API 参考
+- [Sparkling SDK — Android](../apis/sparkling-sdk-android.md) — Android API 参考

--- a/docs/zh/guide/multi-page-navigation.md
+++ b/docs/zh/guide/multi-page-navigation.md
@@ -1,6 +1,6 @@
 # 多页面导航
 
-Sparkling 采用原生容器模型，每个页面运行在独立的原生容器及其对应的 LynxView 中。页面之间通过 scheme URL 驱动导航。
+Sparkling 采用原生[容器](./containers.md)模型，每个页面运行在独立的原生容器及其对应的 LynxView 中。页面之间通过 [scheme URL](./scheme.md) 驱动导航。
 
 在构建配置的 `source.entry` 中定义的每个入口——无论是 `app.config.ts` 中的 `lynxConfig` 还是独立的 `lynx.config.ts`——都会生成一个可导航的 bundle。无需路由注册：bundle 构建完成后，任何页面都可以通过 `navigate()` 函数使用 bundle 路径跳转到该页面。
 

--- a/docs/zh/guide/scheme.md
+++ b/docs/zh/guide/scheme.md
@@ -26,6 +26,8 @@ hybrid://lynxview_page?bundle=detail.lynx.bundle&title=Detail&hide_nav_bar=1
 
 ## 容器类型（Host）
 
+Host 决定使用哪种原生容器来渲染内容。参见[容器](./containers.md)了解各容器模式的详情。
+
 | Host | 描述 |
 | --- | --- |
 | `lynxview_page` | Lynx 页面容器（推荐） |
@@ -54,6 +56,8 @@ hybrid://lynxview_page?bundle=detail.lynx.bundle&title=Detail&hide_nav_bar=1
 完整参数参考请查看 [Scheme API 文档](/apis/scheme)。
 
 ## 在 JS 中使用
+
+通常不需要手动构建 scheme URL。[`navigate()`](/apis/sparkling-methods/sparkling-navigation) 函数会为你构建它们。参见[多页面导航](./multi-page-navigation.md)了解常见的导航模式（传递数据、关闭页面等）。
 
 通常不需要手动构造 scheme URL。[`navigate()`](/apis/sparkling-methods/sparkling-navigation) 函数会自动构建：
 


### PR DESCRIPTION
## Summary
- Add container guide entries to the website sidebar for both EN and ZH locales
- Cross-reference core guide pages (scheme, navigation) with container documentation