### PR TITLE
fix(sdk): persist theme preference and inject into all container globalProps

### DIFF
--- a/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/hybridkit/utils/GlobalPropsUtils.kt
+++ b/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/hybridkit/utils/GlobalPropsUtils.kt
@@ -31,8 +31,33 @@ class GlobalPropsUtils {
     private val removableGlobalKeys = SafeConcurrentHashMap<String, MutableList<String>>()
 
     companion object {
+        private const val PREFS_NAME = "sparkling_global"
+        private const val KEY_PREFERRED_THEME = "preferredTheme"
+
         val instance by lazy(LazyThreadSafetyMode.SYNCHRONIZED) {
             GlobalPropsUtils()
+        }
+
+        /** Persist the user's theme preference so all new containers inherit it. */
+        @JvmStatic
+        fun setPreferredTheme(context: Context, theme: String?) {
+            val prefs = context.applicationContext
+                .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            if (theme.isNullOrBlank()) {
+                prefs.edit().remove(KEY_PREFERRED_THEME).apply()
+            } else {
+                prefs.edit().putString(KEY_PREFERRED_THEME, theme.trim()).apply()
+            }
+        }
+
+        /** Read the persisted theme preference, if any. */
+        @JvmStatic
+        fun getPreferredTheme(context: Context): String? {
+            return context.applicationContext
+                .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .getString(KEY_PREFERRED_THEME, null)
+                ?.trim()
+                ?.ifEmpty { null }
         }
 
         val builtInStableFields = mapOf<String, () -> Any>(
@@ -221,6 +246,9 @@ class GlobalPropsUtils {
                 put("screenOrientation", if (isPortrait) "Portrait" else "Landscape")
                 put("orientation", if (isPortrait) 0 else 1)
                 put("theme", if (hybridContext.getTheme(context) == Theme.DARK) "dark" else "light")
+                context?.let { ctx ->
+                    getPreferredTheme(ctx)?.let { put("preferredTheme", it) }
+                }
             }
             putAll(unstableMap)
         }

--- a/packages/sparkling-sdk/ios/Sparkling/Sources/Service/Base/SPKGlobalPropsUtils.swift
+++ b/packages/sparkling-sdk/ios/Sparkling/Sources/Service/Base/SPKGlobalPropsUtils.swift
@@ -16,6 +16,21 @@ import Foundation
 /// and providing fallback values when necessary.
 @objcMembers
 open class SPKGlobalPropsUtils: NSObject {
+    private static let preferredThemeKey = "sparkling.preferredTheme"
+
+    /// Persist the user's theme preference so all new containers inherit it.
+    public static func setPreferredTheme(_ theme: String?) {
+        if let theme = theme?.trimmingCharacters(in: .whitespacesAndNewlines), !theme.isEmpty {
+            UserDefaults.standard.set(theme, forKey: preferredThemeKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: preferredThemeKey)
+        }
+    }
+
+    /// Read the persisted theme preference, if any.
+    public static func preferredTheme() -> String? {
+        UserDefaults.standard.string(forKey: preferredThemeKey)
+    }
     /// Generates a dictionary of default global properties for the current device and environment.
     /// 
     /// This method collects comprehensive device information including screen dimensions,
@@ -82,7 +97,8 @@ open class SPKGlobalPropsUtils: NSObject {
             "isLowPowerMode": ProcessInfo.processInfo.isLowPowerModeEnabled ? 1 : 0,
             "isAppBackground": UIApplication.shared.applicationState == .background,
             "screenOrientation": self.screenOrientationString(),
-            "deviceModel": UIDevice.spk.hwModel?.lowercased() ?? ""
+            "deviceModel": UIDevice.spk.hwModel?.lowercased() ?? "",
+            "preferredTheme": preferredTheme() ?? ""
         ]
     }
     


### PR DESCRIPTION
Closes #56

## Problem

Sub-pages opened via `navigate()`/`open()` don't inherit the user's in-app theme preference. Each container is an isolated LynxView with its own JS runtime — theme is determined at creation from `force_theme_style` (if set) or the system dark mode setting. There's no mechanism to propagate an in-app preference across containers.

## Solution

Add `setPreferredTheme` / `getPreferredTheme` APIs to the SDK, backed by native persistence:

**iOS** (`SPKGlobalPropsUtils`):
```swift
SPKGlobalPropsUtils.setPreferredTheme("dark")   // persist
SPKGlobalPropsUtils.preferredTheme()              // read
```

**Android** (`GlobalPropsUtils`):
```kotlin
GlobalPropsUtils.setPreferredTheme(context, "dark")  // persist
GlobalPropsUtils.getPreferredTheme(context)           // read
```

The persisted value is automatically injected as `preferredTheme` in `globalProps` for every new container. Frontend `ThemeProvider`s can read `lynx.__globalProps.preferredTheme` to initialize with the correct theme.

## What's NOT in this PR (follow-ups)
- Pipe method for JS to call `setPreferredTheme` (needs a new method in sparkling-method or debug-tool)
- Broadcasting theme changes to already-open containers (`updateGlobalProps` on active views)
- Respecting persisted preference in `HybridContext.getTheme()` when `force_theme_style` is absent

## Test plan
- [ ] iOS: call `SPKGlobalPropsUtils.setPreferredTheme("dark")` → open a sub-page → verify `lynx.__globalProps.preferredTheme == "dark"`
- [ ] Android: call `GlobalPropsUtils.setPreferredTheme(ctx, "light")` → open a sub-page → verify `lynx.__globalProps.preferredTheme == "light"`
- [ ] Verify `preferredTheme` is empty string (iOS) / absent (Android) when no preference is set