### PR TITLE
feat: add zephyr ota support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 Large-scale apps like TikTok are never built with a single technology. Sparkling is the infrastructure we built to unlock [Lynx](https://lynxjs.org) [at TikTok's scale](https://lynxjs.org/next/blog/lynx-unlock-native-for-more#ship-native-at-scale-and-velocity), and we believe it can do the same for your app.
 
 - 📦 **Scaffold in minutes.** Create a Lynx app targeting Android & iOS with a single CLI command.
+- ☁️ **Zephyr-ready scaffolding.** Optional Zephyr deploy support built into the official app template.
 - 🔀 **Scheme-driven navigation.** Route between Lynx pages and native screens with a unified URL scheme.
 - 🧩 **Production-proven native APIs.** Built-in media, storage, and extensible through Sparkling Method.
 

--- a/docs/en/guide/deployment/zephyr-ota.mdx
+++ b/docs/en/guide/deployment/zephyr-ota.mdx
@@ -1,0 +1,128 @@
+# Zephyr OTA for Sparkling
+
+Sparkling can already load remote Lynx bundles. Zephyr OTA support builds on top of that by adding:
+
+- snapshot/version polling
+- tap-to-apply remote bundle activation
+- bundled fallback
+
+## Status
+
+Current state in open source:
+
+- scaffold support: available
+- direct Zephyr deploy from `sparkling-app-cli`: available
+- live OTA resolver against a stable Zephyr `versionUrl`: available
+- built-in `Update ready` badge on pending OTA snapshots: available
+- tap badge to reload current container into latest snapshot: available
+- local cache/hash verification: planned
+
+## Deploy path
+
+Sparkling apps do not need to wrap the Lynx bundler config with a Zephyr plugin.
+
+The current deploy path is:
+
+1. `sparkling-app-cli build`
+2. `sparkling-app-cli deploy:zephyr --target ios|android`
+
+Under the hood, Sparkling calls `uploadOutputToZephyr()` from `zephyr-agent` against the generated `dist/` folder with `ssr: false`.
+
+## App config
+
+Sparkling apps can declare Zephyr OTA intent in `app.config.ts`:
+
+```ts
+import type { AppConfig } from 'sparkling-app-cli'
+
+const config: AppConfig = {
+  zephyr: {
+    enabled: true,
+    appId: 'my-app',
+    versionUrl: process.env.ZEPHYR_VERSION_URL,
+    channel: 'production',
+    strategy: 'next-launch',
+    fallback: 'bundled',
+    polling: {
+      enabled: true,
+      intervalMs: 15 * 60 * 1000,
+    },
+    ios: {
+      target: 'ios',
+    },
+    android: {
+      target: 'android',
+    },
+  },
+}
+```
+
+For real OTA rollouts, set `versionUrl` to a stable Zephyr alias that moves as new builds publish.
+
+```bash
+export ZEPHYR_VERSION_URL='https://t-latest-your-name-my-app-....ze.zephyrcloud.app'
+```
+
+If `versionUrl` is omitted, Sparkling writes the one-off deploy URL returned by `deploy:zephyr` into `dist/sparkling.zephyr.json`. Good enough for direct remote loads; not ideal for continuous OTA unless that URL also tracks the latest snapshot.
+
+For local OTA testing, set a very small polling interval:
+
+```ts
+zephyr: {
+  polling: {
+    enabled: true,
+    intervalMs: 1000,
+  },
+}
+```
+
+## Runtime flow
+
+1. app boots from bundled assets
+2. background poll hits `__get_version_info__` on `zephyr.versionUrl`
+3. if snapshot changed, Sparkling stores the returned `version_url`
+4. the current container shows a small `Update ready` badge
+5. tapping the badge rewrites `bundle=main.lynx.bundle` to `https://.../main.lynx.bundle` and reloads the current container
+6. if the remote load fails, Sparkling shows a retryable error view instead of a blank screen
+
+## Debug logs
+
+For iOS simulator debugging:
+
+```bash
+xcrun simctl spawn booted log stream --level debug --predicate 'eventMessage CONTAINS "SPKZephyrOTAManager" OR eventMessage CONTAINS "SPKViewController" OR eventMessage CONTAINS "SPKWrapperLynxView"'
+```
+
+Useful lines:
+
+- `SPKZephyrOTAManager refresh ...`
+- `SPKViewController applying OTA ...`
+- `SPKWrapperLynxView load: sourceUrl=...`
+- `SPKWrapperLynxView didReceiveError: ...`
+
+## Repo split
+
+`sparkling`
+
+- app config surface
+- native resolver hookup
+- route fallback logic
+- stable-version polling state
+
+`zephyr-packages`
+
+- direct deploy via `zephyr-agent`
+- future cache/hash helpers if Sparkling grows beyond remote-bundle OTA
+
+`zephyr-mono`
+
+- only needed if current version/snapshot endpoints need extra metadata beyond `__get_version_info__`
+
+## Next native work
+
+Next hardening work:
+
+- local download/cache instead of hot remote URLs
+- hash verification
+- route-level manifest
+- method ABI compatibility guard

--- a/docs/en/guide/get-started/create-new-app.mdx
+++ b/docs/en/guide/get-started/create-new-app.mdx
@@ -18,6 +18,13 @@ npm create sparkling-app@latest my-app
 cd my-app
 ```
 
+Optional. Scaffold Zephyr deploy support too:
+
+```bash
+npm create sparkling-app@latest my-app -- --with-zephyr
+cd my-app
+```
+
 ### Run native targets
 
 ```bash
@@ -57,6 +64,13 @@ Key folders/files created by the default template:
 - `android/`, `ios/`: native shells wired to Sparkling SDK
 - `app.config.ts`: build + routing config consumed by `sparkling-app-cli`
 - `package.json`: scripts (`dev`, `build`, `run:android`, `run:ios`)
+
+If you enable Zephyr support, the template also adds:
+
+- `deploy:zephyr:ios` / `deploy:zephyr:android` scripts powered by `sparkling-app-cli`
+- a `zephyr` section in `app.config.ts` for future Sparkling OTA wiring
+
+For the OTA contract and rollout model, see [Zephyr OTA for Sparkling](../deployment/zephyr-ota).
 
 ### Prerequisites
 

--- a/packages/create-sparkling-app/src/__tests__/init.test.ts
+++ b/packages/create-sparkling-app/src/__tests__/init.test.ts
@@ -18,7 +18,7 @@ describe('init command', () => {
   });
 
   it('forwards parsed name and flags to createSparklingApp', async () => {
-    await init(['my-app', '--template', 'sparkling-bare', '--pm', 'pnpm', '--no-install']);
+    await init(['my-app', '--template', 'sparkling-bare', '--pm', 'pnpm', '--no-install', '--with-zephyr']);
 
     expect(mockedCreateSparklingApp).toHaveBeenCalledWith(expect.objectContaining({
       args: { name: 'my-app' },
@@ -26,6 +26,7 @@ describe('init command', () => {
         install: false,
         pm: 'pnpm',
         template: 'sparkling-bare',
+        withZephyr: true,
       }),
       cwd: process.cwd(),
     }));

--- a/packages/create-sparkling-app/src/__tests__/post-create.test.ts
+++ b/packages/create-sparkling-app/src/__tests__/post-create.test.ts
@@ -32,7 +32,7 @@ describe('post-create detectPackageManager', () => {
     process.env.npm_config_user_agent = '';
     mockedExecSync.mockImplementation((command: any) => {
       if (typeof command === 'string' && command.startsWith('pnpm')) {
-        return undefined as unknown as Buffer;
+        return '';
       }
       throw new Error('not installed');
     });

--- a/packages/create-sparkling-app/src/__tests__/postCreate.test.ts
+++ b/packages/create-sparkling-app/src/__tests__/postCreate.test.ts
@@ -32,7 +32,7 @@ describe('postCreate detectPackageManager', () => {
     process.env.npm_config_user_agent = '';
     mockedExecSync.mockImplementation((command: any) => {
       if (typeof command === 'string' && command.startsWith('pnpm')) {
-        return undefined as unknown as Buffer;
+        return '';
       }
       throw new Error('not installed');
     });

--- a/packages/create-sparkling-app/src/__tests__/zephyr.test.ts
+++ b/packages/create-sparkling-app/src/__tests__/zephyr.test.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2025 TikTok Pte. Ltd.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { applyZephyrSupport } from '../create-app/zephyr';
+
+describe('applyZephyrSupport', () => {
+  it('patches package.json and app.config.ts for the default template shape', () => {
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sparkling-zephyr-'));
+
+    fs.writeFileSync(
+      path.join(projectDir, 'package.json'),
+      JSON.stringify({
+        scripts: {
+          build: 'sparkling-app-cli build --copy',
+        },
+        devDependencies: {},
+      }),
+    );
+
+    fs.writeFileSync(
+      path.join(projectDir, 'app.config.ts'),
+      `import { defineConfig } from '@lynx-js/rspeedy'\nimport { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin'\n\nconst lynxConfig = defineConfig({\n  plugins: [pluginReactLynx()],\n})\n\nconst config = {\n  router: {\n    main: {\n      path: './lynxPages/main',\n    },\n  },\n}\n\nexport default config\n`,
+    );
+
+    applyZephyrSupport(projectDir, 'demo-app');
+
+    const packageJson = JSON.parse(fs.readFileSync(path.join(projectDir, 'package.json'), 'utf8')) as {
+      scripts: Record<string, string>;
+      devDependencies: Record<string, string>;
+    };
+    const appConfig = fs.readFileSync(path.join(projectDir, 'app.config.ts'), 'utf8');
+
+    expect(packageJson.scripts['deploy:zephyr:ios']).toBe('sparkling-app-cli deploy:zephyr --target ios');
+    expect(packageJson.scripts['deploy:zephyr:android']).toBe('sparkling-app-cli deploy:zephyr --target android');
+    expect(packageJson.devDependencies['zephyr-cli']).toBeUndefined();
+    expect(packageJson.devDependencies['zephyr-rspack-plugin']).toBeUndefined();
+    expect(appConfig).not.toContain("import { withZephyr } from 'zephyr-rspack-plugin'");
+    expect(appConfig).not.toContain('config = await withZephyr()(config)');
+    expect(appConfig).toContain("appId: 'demo-app'");
+    expect(appConfig).toContain("versionUrl: process.env.ZEPHYR_VERSION_URL");
+    expect(appConfig).toContain("strategy: 'next-launch'");
+    expect(appConfig).toContain("fallback: 'bundled'");
+  });
+});

--- a/packages/create-sparkling-app/src/create-app.ts
+++ b/packages/create-sparkling-app/src/create-app.ts
@@ -47,10 +47,12 @@ import {
   askNamespace,
   askProjectName,
   askTemplate,
+  askZephyrSupport,
   confirmInitGit,
   confirmInstall,
   confirmRemoveExistingDir,
 } from "./create-app/user-prompts";
+import { applyZephyrSupport } from "./create-app/zephyr";
 import { enableVerboseLogging, isVerboseEnabled, verboseLog } from "./utils/verbose";
 
 export type {
@@ -190,6 +192,7 @@ export async function createSparklingApp(
   const devTools = await askDevTools(flags);
 
   const additionalTools = await askAdditionalTools(flags);
+  const withZephyr = await askZephyrSupport(flags);
 
   const defaultNamespace = deriveDefaultNamespace(packageName);
   const packageNamespace = await askNamespace(defaultNamespace, flags);
@@ -272,6 +275,9 @@ export async function createSparklingApp(
         projectDir: config.targetDir,
         selection: androidDsl,
       });
+      if (withZephyr) {
+        applyZephyrSupport(config.targetDir, packageName);
+      }
       applyPackageNamespace(config.targetDir, packageNamespace);
       ensureExecutable(path.join(config.targetDir, "android", "gradlew"));
     },

--- a/packages/create-sparkling-app/src/create-app/types.ts
+++ b/packages/create-sparkling-app/src/create-app/types.ts
@@ -10,6 +10,7 @@ export interface CreateAppArgs {
 export interface CreateAppFlags {
   template?: string;
   templateVersion?: string;
+  withZephyr?: boolean;
   yes?: boolean;
   force?: boolean;
   pm?: string;

--- a/packages/create-sparkling-app/src/create-app/user-prompts.ts
+++ b/packages/create-sparkling-app/src/create-app/user-prompts.ts
@@ -92,6 +92,18 @@ export async function askAdditionalTools(flags: { yes?: boolean }): Promise<stri
   return [];
 }
 
+export async function askZephyrSupport(flags: { yes?: boolean; withZephyr?: boolean }): Promise<boolean> {
+  if (flags.withZephyr !== undefined) return flags.withZephyr;
+  if (!flags.yes) {
+    const withZephyr = await p.confirm({
+      message: 'Add Zephyr deploy support?',
+      initialValue: false,
+    });
+    return checkCancel(withZephyr);
+  }
+  return false;
+}
+
 export async function askNamespace(defaultNamespace: string, flags: { yes?: boolean; namespace?: string; ['app-id']?: string }): Promise<string> {
   const provided = flags.namespace ?? flags['app-id'];
   if (provided) return provided;

--- a/packages/create-sparkling-app/src/create-app/zephyr.ts
+++ b/packages/create-sparkling-app/src/create-app/zephyr.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2025 TikTok Pte. Ltd.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import fs from 'node:fs';
+import path from 'node:path';
+
+function updatePackageJson(projectDir: string): void {
+  const packageJsonPath = path.join(projectDir, 'package.json');
+  if (!fs.existsSync(packageJsonPath)) return;
+
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as {
+    devDependencies?: Record<string, string>;
+    scripts?: Record<string, string>;
+  };
+
+  packageJson.devDependencies ??= {};
+  packageJson.scripts ??= {};
+
+  packageJson.scripts['deploy:zephyr:ios'] ??=
+    'sparkling-app-cli deploy:zephyr --target ios';
+  packageJson.scripts['deploy:zephyr:android'] ??=
+    'sparkling-app-cli deploy:zephyr --target android';
+
+  fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+}
+
+function updateAppConfig(projectDir: string, packageName: string): void {
+  const appConfigPath = path.join(projectDir, 'app.config.ts');
+  if (!fs.existsSync(appConfigPath)) return;
+
+  let source = fs.readFileSync(appConfigPath, 'utf8');
+
+  if (!source.includes('zephyr: {')) {
+    source = source.replace(
+      "  router: {\n",
+      `  zephyr: {\n    enabled: true,\n    appId: '${packageName}',\n    versionUrl: process.env.ZEPHYR_VERSION_URL,\n    strategy: 'next-launch',\n    fallback: 'bundled',\n    polling: {\n      enabled: true,\n      intervalMs: 15 * 60 * 1000,\n    },\n    ios: {\n      target: 'ios',\n    },\n    android: {\n      target: 'android',\n    },\n  },\n  router: {\n`,
+    );
+  }
+
+  fs.writeFileSync(appConfigPath, source);
+}
+
+export function applyZephyrSupport(projectDir: string, packageName: string): void {
+  updatePackageJson(projectDir);
+  updateAppConfig(projectDir, packageName);
+}

--- a/packages/create-sparkling-app/src/init.ts
+++ b/packages/create-sparkling-app/src/init.ts
@@ -13,6 +13,7 @@ function parseFlags(argv: string[]): { name?: string; flags: CreateAppFlags } {
     .argument('[name]')
     .option('-t, --template <name>', 'Template name or path')
     .option('--template-version <version>', 'Template version or tag')
+    .option('--with-zephyr', 'Scaffold Zephyr deploy support')
     .option('-y, --yes', 'Skip all prompts')
     .option('-f, --force', 'Force overwrite existing directory')
     .option('--pm <pm>', 'Package manager to use')
@@ -28,6 +29,7 @@ function parseFlags(argv: string[]): { name?: string; flags: CreateAppFlags } {
   const opts = parsed.opts<{
     template?: string;
     templateVersion?: string;
+    withZephyr?: boolean;
     yes?: boolean;
     force?: boolean;
     pm?: string;
@@ -42,6 +44,7 @@ function parseFlags(argv: string[]): { name?: string; flags: CreateAppFlags } {
 
   const flags: CreateAppFlags = {
     template: opts.template,
+    withZephyr: opts.withZephyr,
     yes: opts.yes,
     force: opts.force,
     pm: opts.pm,

--- a/packages/sparkling-app-cli/package.json
+++ b/packages/sparkling-app-cli/package.json
@@ -30,7 +30,8 @@
     "fast-glob": "^3.3.3",
     "fs-extra": "^11.2.0",
     "semver": "^7.6.0",
-    "ts-node": "^10.9.2"
+    "ts-node": "^10.9.2",
+    "zephyr-agent": "^1.0.0"
   },
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",

--- a/packages/sparkling-app-cli/src/__tests__/deploy-zephyr.test.ts
+++ b/packages/sparkling-app-cli/src/__tests__/deploy-zephyr.test.ts
@@ -1,0 +1,135 @@
+jest.mock('../config', () => ({
+  loadAppConfig: jest.fn(),
+}));
+
+jest.mock('../commands/build', () => ({
+  buildProject: jest.fn(),
+}));
+
+jest.mock('../commands/copy-assets', () => ({
+  copyAssets: jest.fn(),
+}));
+
+jest.mock('../commands/zephyr-runtime-config', () => ({
+  writeZephyrRuntimeConfig: jest.fn(),
+}));
+
+jest.mock('zephyr-agent', () => ({
+  uploadOutputToZephyr: jest.fn(),
+}));
+
+import { loadAppConfig } from '../config';
+import { buildProject } from '../commands/build';
+import { copyAssets } from '../commands/copy-assets';
+import { deployToZephyr, resolveZephyrDeployTarget } from '../commands/deploy-zephyr';
+import { writeZephyrRuntimeConfig } from '../commands/zephyr-runtime-config';
+import { uploadOutputToZephyr } from 'zephyr-agent';
+
+const mockedLoadAppConfig = loadAppConfig as jest.MockedFunction<typeof loadAppConfig>;
+const mockedBuildProject = buildProject as jest.MockedFunction<typeof buildProject>;
+const mockedCopyAssets = copyAssets as jest.MockedFunction<typeof copyAssets>;
+const mockedWriteZephyrRuntimeConfig =
+  writeZephyrRuntimeConfig as jest.MockedFunction<typeof writeZephyrRuntimeConfig>;
+const mockedUploadOutputToZephyr = uploadOutputToZephyr as jest.MockedFunction<typeof uploadOutputToZephyr>;
+
+describe('resolveZephyrDeployTarget', () => {
+  it('uses the explicit target when provided', () => {
+    expect(resolveZephyrDeployTarget({ lynxConfig: {} } as any, 'ios')).toBe('ios');
+  });
+
+  it('uses the configured target when exactly one exists', () => {
+    expect(resolveZephyrDeployTarget({
+      lynxConfig: {},
+      zephyr: {
+        ios: { target: 'ios' },
+      },
+    } as any)).toBe('ios');
+  });
+});
+
+describe('deployToZephyr', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedLoadAppConfig.mockResolvedValue({
+      config: {
+        lynxConfig: {},
+        zephyr: {
+          ios: { target: 'ios' },
+        },
+      } as any,
+      configPath: '/tmp/app.config.ts',
+    });
+    mockedBuildProject.mockResolvedValue();
+    mockedCopyAssets.mockResolvedValue();
+    mockedWriteZephyrRuntimeConfig.mockReturnValue('/tmp/demo/dist/sparkling.zephyr.json');
+    mockedUploadOutputToZephyr.mockResolvedValue({
+      deploymentUrl: 'https://deploy.example.com',
+    });
+  });
+
+  it('builds and uploads with ssr disabled', async () => {
+    await deployToZephyr({
+      cwd: '/tmp/demo',
+    });
+
+    expect(mockedBuildProject).toHaveBeenCalledWith({
+      cwd: '/tmp/demo',
+      configFile: 'app.config.ts',
+      skipCopy: true,
+    });
+    expect(mockedUploadOutputToZephyr).toHaveBeenCalledWith({
+      rootDir: '/tmp/demo',
+      outputDir: 'dist',
+      builder: 'rspack',
+      target: 'ios',
+      ssr: false,
+    });
+    expect(mockedWriteZephyrRuntimeConfig).toHaveBeenCalledWith({
+      cwd: '/tmp/demo',
+      config: {
+        lynxConfig: {},
+        zephyr: {
+          ios: { target: 'ios' },
+        },
+      },
+      sourceDir: 'dist',
+      versionUrlOverride: 'https://deploy.example.com',
+    });
+    expect(mockedCopyAssets).toHaveBeenCalledWith({
+      cwd: '/tmp/demo',
+      source: 'dist',
+      androidDest: 'android/app/src/main/assets',
+      iosDest: 'ios/LynxResources/Assets',
+    });
+  });
+
+  it('preserves configured versionUrl for OTA when present', async () => {
+    mockedLoadAppConfig.mockResolvedValueOnce({
+      config: {
+        lynxConfig: {},
+        zephyr: {
+          versionUrl: 'https://stable.example.com',
+          ios: { target: 'ios' },
+        },
+      } as any,
+      configPath: '/tmp/app.config.ts',
+    });
+
+    await deployToZephyr({
+      cwd: '/tmp/demo',
+    });
+
+    expect(mockedWriteZephyrRuntimeConfig).toHaveBeenCalledWith({
+      cwd: '/tmp/demo',
+      config: {
+        lynxConfig: {},
+        zephyr: {
+          versionUrl: 'https://stable.example.com',
+          ios: { target: 'ios' },
+        },
+      },
+      sourceDir: 'dist',
+      versionUrlOverride: 'https://stable.example.com',
+    });
+  });
+});

--- a/packages/sparkling-app-cli/src/__tests__/zephyr-runtime-config.test.ts
+++ b/packages/sparkling-app-cli/src/__tests__/zephyr-runtime-config.test.ts
@@ -1,0 +1,58 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { writeZephyrRuntimeConfig, ZEPHYR_RUNTIME_CONFIG_FILE } from '../commands/zephyr-runtime-config';
+
+describe('writeZephyrRuntimeConfig', () => {
+  it('writes a normalized runtime config into dist', () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'sparkling-zephyr-runtime-'));
+
+    const outputPath = writeZephyrRuntimeConfig({
+      cwd,
+      config: {
+        lynxConfig: {},
+        zephyr: {
+          enabled: true,
+          appId: 'demo-app',
+          versionUrl: 'demo.zephyrcloud.app/',
+          polling: {
+            intervalMs: 30_000,
+          },
+        },
+      },
+    });
+
+    expect(outputPath).toBe(path.join(cwd, 'dist', ZEPHYR_RUNTIME_CONFIG_FILE));
+    const contents = JSON.parse(fs.readFileSync(outputPath!, 'utf8'));
+    expect(contents).toEqual({
+      version: 1,
+      enabled: true,
+      appId: 'demo-app',
+      strategy: 'next-launch',
+      fallback: 'bundled',
+      versionUrl: 'https://demo.zephyrcloud.app',
+      polling: {
+        enabled: true,
+        intervalMs: 30_000,
+      },
+    });
+  });
+
+  it('removes stale config when zephyr support is disabled', () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'sparkling-zephyr-runtime-'));
+    const distDir = path.join(cwd, 'dist');
+    fs.mkdirSync(distDir, { recursive: true });
+    const outputPath = path.join(distDir, ZEPHYR_RUNTIME_CONFIG_FILE);
+    fs.writeFileSync(outputPath, '{}\n');
+
+    const result = writeZephyrRuntimeConfig({
+      cwd,
+      config: {
+        lynxConfig: {},
+      },
+    });
+
+    expect(result).toBeNull();
+    expect(fs.existsSync(outputPath)).toBe(false);
+  });
+});

--- a/packages/sparkling-app-cli/src/commands/build.ts
+++ b/packages/sparkling-app-cli/src/commands/build.ts
@@ -7,6 +7,7 @@ import { runCommand } from '../utils/exec';
 import { ui } from '../utils/ui';
 import { isVerboseEnabled, verboseLog } from '../utils/verbose';
 import { copyAssets } from './copy-assets';
+import { writeZephyrRuntimeConfig } from './zephyr-runtime-config';
 
 export interface BuildOptions {
   cwd: string;
@@ -28,10 +29,14 @@ export async function buildProject(options: BuildOptions): Promise<void> {
   console.log(ui.headline(`Building Lynx bundle with config from ${path.relative(options.cwd, configPath)}`));
   await runCommand(rspeedyBin, ['build', '--config', tempConfigPath], { cwd: options.cwd });
 
+  const { config } = await loadAppConfig(options.cwd, options.configFile ?? 'app.config.ts');
+  writeZephyrRuntimeConfig({
+    cwd: options.cwd,
+    config,
+  });
+
   const shouldCopy = options.skipCopy !== true; // default to no copy
   if (shouldCopy) {
-    // Read AppConfig to locate platform asset destinations if provided
-    const { config } = await loadAppConfig(options.cwd, options.configFile ?? 'app.config.ts');
     await copyAssets({
       cwd: options.cwd,
       androidDest: config.paths?.androidAssets ?? 'android/app/src/main/assets',

--- a/packages/sparkling-app-cli/src/commands/deploy-zephyr.ts
+++ b/packages/sparkling-app-cli/src/commands/deploy-zephyr.ts
@@ -1,0 +1,93 @@
+// Copyright (c) 2025 TikTok Pte. Ltd.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { loadAppConfig } from '../config';
+import type { AppConfig, ZephyrDeployTarget } from '../types';
+import { ui } from '../utils/ui';
+import { buildProject } from './build';
+import { copyAssets } from './copy-assets';
+import { writeZephyrRuntimeConfig } from './zephyr-runtime-config';
+import { uploadOutputToZephyr } from 'zephyr-agent';
+
+const ALLOWED_TARGETS: ZephyrDeployTarget[] = ['android', 'ios', 'web'];
+
+export interface DeployZephyrOptions {
+  cwd: string;
+  configFile?: string;
+  target?: string;
+  outputDir?: string;
+  skipBuild?: boolean;
+}
+
+function getConfiguredTargets(config: AppConfig): ZephyrDeployTarget[] {
+  const targets = [
+    config.zephyr?.android?.target,
+    config.zephyr?.ios?.target,
+  ].filter((target): target is ZephyrDeployTarget => Boolean(target));
+
+  return [...new Set(targets)];
+}
+
+export function resolveZephyrDeployTarget(config: AppConfig, explicitTarget?: string): ZephyrDeployTarget {
+  if (explicitTarget) {
+    const normalized = explicitTarget.toLowerCase();
+    if (ALLOWED_TARGETS.includes(normalized as ZephyrDeployTarget)) {
+      return normalized as ZephyrDeployTarget;
+    }
+    throw new Error(`Unsupported Zephyr deploy target "${explicitTarget}". Use android, ios, or web.`);
+  }
+
+  const configuredTargets = getConfiguredTargets(config);
+  if (configuredTargets.length === 1) {
+    return configuredTargets[0];
+  }
+
+  if (configuredTargets.length > 1) {
+    throw new Error('Multiple Zephyr targets configured. Pass --target android or --target ios.');
+  }
+
+  throw new Error('Missing Zephyr deploy target. Pass --target android|ios|web or configure app.config.ts.');
+}
+
+export async function deployToZephyr(options: DeployZephyrOptions): Promise<void> {
+  const configFile = options.configFile ?? 'app.config.ts';
+  const { config } = await loadAppConfig(options.cwd, configFile);
+  const target = resolveZephyrDeployTarget(config, options.target);
+
+  if (options.skipBuild !== true) {
+    await buildProject({
+      cwd: options.cwd,
+      configFile,
+      skipCopy: true,
+    });
+  }
+
+  console.log(ui.headline(`Deploying dist to Zephyr (${target})`));
+  const result = await uploadOutputToZephyr({
+    rootDir: options.cwd,
+    outputDir: options.outputDir ?? 'dist',
+    builder: 'rspack',
+    target,
+    ssr: false,
+  });
+
+  writeZephyrRuntimeConfig({
+    cwd: options.cwd,
+    config,
+    sourceDir: options.outputDir ?? 'dist',
+    versionUrlOverride: config.zephyr?.versionUrl ?? result.deploymentUrl ?? undefined,
+  });
+  await copyAssets({
+    cwd: options.cwd,
+    source: options.outputDir ?? 'dist',
+    androidDest: config.paths?.androidAssets ?? 'android/app/src/main/assets',
+    iosDest: config.paths?.iosAssets ?? 'ios/LynxResources/Assets',
+  });
+
+  if (result.deploymentUrl) {
+    console.log(ui.success(`✔ Zephyr deploy complete: ${result.deploymentUrl}`));
+    return;
+  }
+
+  console.log(ui.success('✔ Zephyr deploy complete'));
+}

--- a/packages/sparkling-app-cli/src/commands/zephyr-runtime-config.ts
+++ b/packages/sparkling-app-cli/src/commands/zephyr-runtime-config.ts
@@ -1,0 +1,80 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { AppConfig, ZephyrConfig } from '../types';
+
+export const ZEPHYR_RUNTIME_CONFIG_FILE = 'sparkling.zephyr.json';
+const DEFAULT_POLLING_INTERVAL_MS = 15 * 60 * 1000;
+
+export interface ZephyrRuntimeConfig {
+  version: 1;
+  enabled: boolean;
+  appId?: string;
+  channel?: string;
+  versionUrl?: string;
+  strategy: 'next-launch' | 'prompt-restart';
+  fallback: 'bundled';
+  polling: {
+    enabled: boolean;
+    intervalMs: number;
+  };
+}
+
+export interface WriteZephyrRuntimeConfigOptions {
+  cwd: string;
+  config: AppConfig;
+  sourceDir?: string;
+  versionUrlOverride?: string;
+}
+
+function normalizeVersionUrl(value?: string): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed.replace(/\/+$/, '');
+  }
+  return `https://${trimmed.replace(/^\/+/, '').replace(/\/+$/, '')}`;
+}
+
+function createRuntimeConfig(
+  zephyr: ZephyrConfig,
+  versionUrlOverride?: string
+): ZephyrRuntimeConfig {
+  return {
+    version: 1,
+    enabled: zephyr.enabled !== false,
+    appId: zephyr.appId,
+    channel: zephyr.channel,
+    versionUrl: normalizeVersionUrl(versionUrlOverride ?? zephyr.versionUrl),
+    strategy: zephyr.strategy ?? 'next-launch',
+    fallback: zephyr.fallback ?? 'bundled',
+    polling: {
+      enabled: zephyr.polling?.enabled !== false,
+      intervalMs: zephyr.polling?.intervalMs ?? DEFAULT_POLLING_INTERVAL_MS,
+    },
+  };
+}
+
+export function writeZephyrRuntimeConfig(
+  options: WriteZephyrRuntimeConfigOptions
+): string | null {
+  const outputPath = path.resolve(
+    options.cwd,
+    options.sourceDir ?? 'dist',
+    ZEPHYR_RUNTIME_CONFIG_FILE
+  );
+  const zephyr = options.config.zephyr;
+
+  if (!zephyr?.enabled) {
+    if (fs.existsSync(outputPath)) {
+      fs.rmSync(outputPath, { force: true });
+    }
+    return null;
+  }
+
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  const runtimeConfig = createRuntimeConfig(zephyr, options.versionUrlOverride);
+  fs.writeFileSync(outputPath, `${JSON.stringify(runtimeConfig, null, 2)}\n`);
+  return outputPath;
+}

--- a/packages/sparkling-app-cli/src/config.ts
+++ b/packages/sparkling-app-cli/src/config.ts
@@ -140,7 +140,7 @@ function loadAppConfigViaEsm(cwd: string, configPath: string, originalError?: un
     `const url = ${JSON.stringify(fileUrl)};`,
     'const mod = await import(url);',
     'const cfg = (mod.default ?? mod);',
-    'const out = { lynxConfig: cfg.lynxConfig ?? {}, platform: cfg.platform ?? {}, paths: cfg.paths ?? {}, appName: cfg.appName, devtool: cfg.devtool };',
+    'const out = { lynxConfig: cfg.lynxConfig ?? {}, platform: cfg.platform ?? {}, paths: cfg.paths ?? {}, appName: cfg.appName, devtool: cfg.devtool, zephyr: cfg.zephyr ?? undefined };',
     'process.stdout.write(JSON.stringify(out));',
   ].join('\n');
   fs.writeFileSync(readerScript, script);

--- a/packages/sparkling-app-cli/src/index.ts
+++ b/packages/sparkling-app-cli/src/index.ts
@@ -8,6 +8,7 @@ import { autolink } from './commands/autolink';
 import { buildProject } from './commands/build';
 import { copyAssets } from './commands/copy-assets';
 import { devProject } from './commands/dev';
+import { deployToZephyr } from './commands/deploy-zephyr';
 import { doctor } from './commands/doctor';
 import { runAndroid } from './commands/run-android';
 import { runIos } from './commands/run-ios';
@@ -81,6 +82,24 @@ program
       source: opts.source,
       androidDest: opts.androidDest,
       iosDest: opts.iosDest,
+    });
+  });
+
+program
+  .command('deploy:zephyr')
+  .description('Build dist and upload Lynx bundles to Zephyr')
+  .option('--config <path>', 'Path to app.config.ts', 'app.config.ts')
+  .option('--target <platform>', 'Deployment target: android|ios|web')
+  .option('--output-dir <path>', 'Path to compiled assets', 'dist')
+  .option('--skip-build', 'Skip build and upload the existing output directory')
+  .action(async opts => {
+    const cwd = process.cwd();
+    await deployToZephyr({
+      cwd,
+      configFile: opts.config,
+      target: opts.target,
+      outputDir: opts.outputDir,
+      skipBuild: opts.skipBuild,
     });
   });
 

--- a/packages/sparkling-app-cli/src/types.ts
+++ b/packages/sparkling-app-cli/src/types.ts
@@ -35,6 +35,31 @@ export interface SplashScreenPluginConfig {
   };
 }
 
+export type ZephyrDeployTarget = 'android' | 'ios' | 'web';
+export type ZephyrOtaStrategy = 'next-launch' | 'prompt-restart';
+export type ZephyrOtaFallback = 'bundled';
+
+export interface ZephyrPlatformConfig {
+  target?: ZephyrDeployTarget;
+}
+
+export interface ZephyrPollingConfig {
+  enabled?: boolean;
+  intervalMs?: number;
+}
+
+export interface ZephyrConfig {
+  enabled?: boolean;
+  appId?: string;
+  channel?: string;
+  versionUrl?: string;
+  strategy?: ZephyrOtaStrategy;
+  fallback?: ZephyrOtaFallback;
+  polling?: ZephyrPollingConfig;
+  android?: ZephyrPlatformConfig;
+  ios?: ZephyrPlatformConfig;
+}
+
 export type PluginConfig =
   | ['splash-screen', SplashScreenPluginConfig]
   | [string, Record<string, unknown>?];
@@ -42,6 +67,7 @@ export type PluginConfig =
 export interface AppConfig {
   lynxConfig: LynxConfig;
   appName?: string;
+  zephyr?: ZephyrConfig;
   platform?: PlatformConfig;
   paths?: {
     androidAssets?: string;

--- a/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/Sparkling.kt
+++ b/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/Sparkling.kt
@@ -6,6 +6,7 @@ package com.tiktok.sparkling
 import android.content.Context
 import android.content.Intent
 import android.util.Log
+import com.tiktok.sparkling.ota.ZephyrOtaManager
 import com.tiktok.sparkling.utils.SchemeParser
 
 class Sparkling private constructor(
@@ -64,7 +65,10 @@ class Sparkling private constructor(
         val scheme = context.scheme
         if (!scheme.isNullOrBlank()) {
             try {
-                context.hybridSchemeParam = SchemeParser.parseScheme(scheme)
+                context.hybridSchemeParam = SchemeParser.parseScheme(scheme)?.apply {
+                    bundle = ZephyrOtaManager.resolveBundle(this@Sparkling.context, bundle)
+                }
+                ZephyrOtaManager.refreshIfNeeded(this.context)
             } catch (e: Exception) {
                 Log.w(TAG, "Failed to parse scheme: ${e.message}")
             }

--- a/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/SparklingView.kt
+++ b/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/SparklingView.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.graphics.Color
 import android.os.Looper
 import android.util.AttributeSet
+import android.util.TypedValue
 import android.view.Gravity
 import android.view.View
 import android.widget.FrameLayout
@@ -21,6 +22,9 @@ import com.tiktok.sparkling.hybridkit.base.IHybridView
 import com.tiktok.sparkling.hybridkit.base.IKitView
 import com.tiktok.sparkling.hybridkit.base.IPerformanceView
 import com.tiktok.sparkling.hybridkit.utils.ColorUtil
+import com.tiktok.sparkling.ota.ZephyrOtaManager
+import com.tiktok.sparkling.ota.ZephyrVersionInfo
+import com.tiktok.sparkling.utils.SchemeParser
 import org.json.JSONObject
 
 
@@ -35,7 +39,17 @@ class SparklingView(
     private var hideLoading: Boolean = false
     private var hideError: Boolean = false
     private var kitViewDelegate: IKitView? = null
+    private var otaBadgeView: TextView? = null
     var sparklingContext: SparklingContext? = null
+    private val otaListener = object : ZephyrOtaManager.Listener {
+        override fun onUpdateReady(info: ZephyrVersionInfo) {
+            if (Looper.myLooper() != Looper.getMainLooper()) {
+                post { showOtaBadge() }
+            } else {
+                showOtaBadge()
+            }
+        }
+    }
     // private var debugInfoTag: TextView? = null
 
     private var loadStatus = IPerformanceView.LoadStatus.INIT
@@ -84,6 +98,8 @@ class SparklingView(
         loadingViewBgColor?.let { color ->
             loadingView?.setBackgroundColor(color)
         }
+        setupOtaBadge()
+        ZephyrOtaManager.startPolling(context)
 
 
         val kitView = HybridKit.createKitView(
@@ -127,6 +143,7 @@ class SparklingView(
         )
         kitViewDelegate = kitView
         addView(kitView?.realView())
+        otaBadgeView?.let(::bringChildToFront)
 
         handleUI()
 
@@ -189,9 +206,12 @@ class SparklingView(
     override fun release() {
         if (isReleased) return
         isReleased = true
+        ZephyrOtaManager.removeListener(otaListener)
+        ZephyrOtaManager.stopPolling()
         kitViewDelegate?.destroy(true)
         loadingView = null
         errorView = null
+        otaBadgeView = null
         sparklingContext = null
     }
 
@@ -217,6 +237,72 @@ class SparklingView(
             }
         }
         // addDebugTagView()
+    }
+
+    private fun setupOtaBadge() {
+        val badge = otaBadgeView ?: TextView(context).apply {
+            text = "Update ready · tap"
+            setTextColor(Color.WHITE)
+            setTextSize(TypedValue.COMPLEX_UNIT_SP, 12f)
+            setPadding(dp(10), dp(6), dp(10), dp(6))
+            setBackgroundResource(android.R.drawable.toast_frame)
+            layoutParams = LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT).apply {
+                gravity = Gravity.TOP or Gravity.END
+                topMargin = dp(12)
+                marginEnd = dp(12)
+            }
+            visibility = View.GONE
+            elevation = dp(6).toFloat()
+            isClickable = true
+            isFocusable = true
+            setOnClickListener { applyPendingOtaUpdate() }
+        }
+        otaBadgeView = badge
+        if (badge.parent == null) {
+            addView(badge)
+        }
+
+        ZephyrOtaManager.removeListener(otaListener)
+        ZephyrOtaManager.addListener(otaListener)
+        if (ZephyrOtaManager.hasPendingUpdate(context)) {
+            showOtaBadge()
+        } else {
+            hideOtaBadge()
+        }
+    }
+
+    private fun showOtaBadge() {
+        otaBadgeView?.visibility = View.VISIBLE
+        otaBadgeView?.let(::bringChildToFront)
+    }
+
+    private fun hideOtaBadge() {
+        otaBadgeView?.visibility = View.GONE
+    }
+
+    private fun dp(value: Int): Int {
+        return TypedValue.applyDimension(
+            TypedValue.COMPLEX_UNIT_DIP,
+            value.toFloat(),
+            resources.displayMetrics,
+        ).toInt()
+    }
+
+    private fun applyPendingOtaUpdate() {
+        val currentContext = sparklingContext ?: return
+        val scheme = currentContext.scheme ?: return
+        if (!ZephyrOtaManager.applyPendingUpdateIfNeeded(context)) {
+            hideOtaBadge()
+            return
+        }
+        val updatedParam = SchemeParser.parseScheme(scheme)?.apply {
+            bundle = ZephyrOtaManager.resolveBundle(context, bundle)
+        } ?: return
+
+        currentContext.hybridSchemeParam = updatedParam
+        kitViewDelegate?.refreshSchemeParam(updatedParam)
+        hideOtaBadge()
+        kitViewDelegate?.reload()
     }
 
     /*

--- a/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/hybridkit/lynx/SimpleLynxKitView.kt
+++ b/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/hybridkit/lynx/SimpleLynxKitView.kt
@@ -17,6 +17,7 @@ import com.tiktok.sparkling.hybridkit.KitViewManager
 import com.tiktok.sparkling.hybridkit.base.IGetDataCallback
 import com.tiktok.sparkling.hybridkit.base.IHybridKitLifeCycle
 import com.tiktok.sparkling.hybridkit.base.IKitView
+import com.tiktok.sparkling.hybridkit.scheme.HybridSchemeParam
 import com.tiktok.sparkling.hybridkit.utils.GlobalPropsUtils
 import com.tiktok.sparkling.hybridkit.utils.LogLevel
 import com.tiktok.sparkling.hybridkit.utils.LogUtils
@@ -91,6 +92,11 @@ class SimpleLynxKitView : LynxView, IKitView {
         rawUrl?.let {
             load(it)
         }
+    }
+
+    override fun refreshSchemeParam(hybridSchemeParam: HybridSchemeParam) {
+        this.hybridContext.hybridSchemeParam = hybridSchemeParam
+        this.rawUrl = hybridSchemeParam.bundle
     }
 
     override fun updateData(data: Map<String, Any>) {

--- a/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/ota/ZephyrOtaManager.kt
+++ b/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/ota/ZephyrOtaManager.kt
@@ -1,0 +1,331 @@
+// Copyright (c) 2025 TikTok Pte. Ltd.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+package com.tiktok.sparkling.ota
+
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import org.json.JSONObject
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.concurrent.CopyOnWriteArraySet
+import kotlin.concurrent.thread
+
+internal data class ZephyrOtaRuntimeConfig(
+    val enabled: Boolean,
+    val versionUrl: String?,
+    val pollingEnabled: Boolean,
+    val pollingIntervalMs: Long
+)
+
+data class ZephyrVersionInfo(
+    val snapshotId: String,
+    val versionUrl: String
+)
+
+object ZephyrOtaManager {
+    interface Listener {
+        fun onUpdateReady(info: ZephyrVersionInfo)
+    }
+
+    private const val TAG = "SparklingZephyrOTA"
+    private const val PREFS_NAME = "sparkling_zephyr_ota"
+    private const val CONFIG_FILE = "sparkling.zephyr.json"
+    private const val VERSION_INFO_PATH = "__get_version_info__"
+    private const val KEY_APPLIED_SNAPSHOT_ID = "applied_snapshot_id"
+    private const val KEY_APPLIED_VERSION_URL = "applied_version_url"
+    private const val KEY_PENDING_SNAPSHOT_ID = "pending_snapshot_id"
+    private const val KEY_PENDING_VERSION_URL = "pending_version_url"
+    private const val KEY_PENDING_UPDATE_AVAILABLE = "pending_update_available"
+    private const val KEY_LAST_CHECK_AT = "last_check_at"
+    private const val DEFAULT_INTERVAL_MS = 15 * 60 * 1000L
+    private const val MIN_POLL_DELAY_MS = 1_000L
+
+    @Volatile
+    private var refreshInFlight = false
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val listeners = CopyOnWriteArraySet<Listener>()
+    private var pollingRunnable: Runnable? = null
+    private var pollingContext: Context? = null
+
+    fun addListener(listener: Listener) {
+        listeners.add(listener)
+    }
+
+    fun removeListener(listener: Listener) {
+        listeners.remove(listener)
+    }
+
+    fun hasPendingUpdate(context: Context): Boolean {
+        return context
+            .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getBoolean(KEY_PENDING_UPDATE_AVAILABLE, false)
+    }
+
+    fun resolveBundle(context: Context, bundle: String?): String? {
+        if (bundle.isNullOrBlank() || isRemoteUrl(bundle)) {
+            return bundle
+        }
+
+        val config = readRuntimeConfig(context) ?: return bundle
+        if (!config.enabled) {
+            return bundle
+        }
+
+        val appliedVersionUrl = context
+            .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getString(KEY_APPLIED_VERSION_URL, null)
+
+        return joinBundleUrl(appliedVersionUrl, bundle) ?: bundle
+    }
+
+    fun applyPendingUpdateIfNeeded(context: Context): Boolean {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val pendingSnapshotId = prefs.getString(KEY_PENDING_SNAPSHOT_ID, null)
+        val pendingVersionUrl = prefs.getString(KEY_PENDING_VERSION_URL, null)
+        if (!prefs.getBoolean(KEY_PENDING_UPDATE_AVAILABLE, false) ||
+            pendingSnapshotId.isNullOrBlank() ||
+            pendingVersionUrl.isNullOrBlank()
+        ) {
+            return false
+        }
+
+        prefs.edit()
+            .putString(KEY_APPLIED_SNAPSHOT_ID, pendingSnapshotId)
+            .putString(KEY_APPLIED_VERSION_URL, pendingVersionUrl)
+            .remove(KEY_PENDING_SNAPSHOT_ID)
+            .remove(KEY_PENDING_VERSION_URL)
+            .putBoolean(KEY_PENDING_UPDATE_AVAILABLE, false)
+            .apply()
+        return true
+    }
+
+    fun refreshIfNeeded(context: Context) {
+        val appContext = context.applicationContext
+        val config = readRuntimeConfig(appContext) ?: return
+        if (!config.enabled || !config.pollingEnabled) {
+            return
+        }
+
+        val checkBaseUrl = normalizeVersionUrl(config.versionUrl) ?: return
+        val prefs = appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val now = System.currentTimeMillis()
+        val lastCheckAt = prefs.getLong(KEY_LAST_CHECK_AT, 0L)
+        if (now - lastCheckAt < config.pollingIntervalMs.coerceAtLeast(0L)) {
+            return
+        }
+
+        synchronized(this) {
+            if (refreshInFlight) {
+                return
+            }
+            refreshInFlight = true
+            prefs.edit().putLong(KEY_LAST_CHECK_AT, now).apply()
+        }
+
+        thread(name = "sparkling-zephyr-ota", isDaemon = true) {
+            try {
+                val versionInfo = fetchVersionInfo(checkBaseUrl) ?: return@thread
+                val appliedSnapshotId = prefs.getString(KEY_APPLIED_SNAPSHOT_ID, null)
+                val pendingSnapshotId = prefs.getString(KEY_PENDING_SNAPSHOT_ID, null)
+                val normalizedNextSnapshotId = versionInfo.snapshotId.trim()
+                val shouldNotify = when {
+                    appliedSnapshotId.isNullOrBlank() -> {
+                        prefs.edit()
+                            .putString(KEY_APPLIED_SNAPSHOT_ID, normalizedNextSnapshotId)
+                            .putString(KEY_APPLIED_VERSION_URL, versionInfo.versionUrl)
+                            .remove(KEY_PENDING_SNAPSHOT_ID)
+                            .remove(KEY_PENDING_VERSION_URL)
+                            .putBoolean(KEY_PENDING_UPDATE_AVAILABLE, false)
+                            .putLong(KEY_LAST_CHECK_AT, System.currentTimeMillis())
+                            .apply()
+                        false
+                    }
+                    shouldMarkUpdateReady(appliedSnapshotId, normalizedNextSnapshotId) -> {
+                        prefs.edit()
+                            .putString(KEY_PENDING_SNAPSHOT_ID, normalizedNextSnapshotId)
+                            .putString(KEY_PENDING_VERSION_URL, versionInfo.versionUrl)
+                            .putBoolean(KEY_PENDING_UPDATE_AVAILABLE, true)
+                            .putLong(KEY_LAST_CHECK_AT, System.currentTimeMillis())
+                            .apply()
+                        pendingSnapshotId?.trim() != normalizedNextSnapshotId
+                    }
+                    else -> {
+                        prefs.edit()
+                            .remove(KEY_PENDING_SNAPSHOT_ID)
+                            .remove(KEY_PENDING_VERSION_URL)
+                            .putBoolean(KEY_PENDING_UPDATE_AVAILABLE, false)
+                            .putLong(KEY_LAST_CHECK_AT, System.currentTimeMillis())
+                            .apply()
+                        false
+                    }
+                }
+                Log.d(
+                    TAG,
+                    "refresh applied=${appliedSnapshotId ?: "nil"} pending=${pendingSnapshotId ?: "nil"} next=${versionInfo.snapshotId} notify=$shouldNotify versionUrl=${versionInfo.versionUrl}"
+                )
+                if (shouldNotify) {
+                    notifyUpdateReady(versionInfo)
+                }
+            } catch (error: Exception) {
+                Log.w(TAG, "Zephyr OTA refresh failed: ${error.message}")
+            } finally {
+                refreshInFlight = false
+            }
+        }
+    }
+
+    fun startPolling(context: Context) {
+        val appContext = context.applicationContext
+        val config = readRuntimeConfig(appContext) ?: return
+        if (!config.enabled || !config.pollingEnabled) {
+            stopPolling()
+            return
+        }
+
+        val delayMs = config.pollingIntervalMs.coerceAtLeast(MIN_POLL_DELAY_MS)
+        synchronized(this) {
+            if (pollingContext === appContext && pollingRunnable != null) {
+                return
+            }
+            stopPollingLocked()
+            pollingContext = appContext
+            pollingRunnable = object : Runnable {
+                override fun run() {
+                    refreshIfNeeded(appContext)
+                    mainHandler.postDelayed(this, delayMs)
+                }
+            }.also { runnable ->
+                mainHandler.post(runnable)
+            }
+        }
+    }
+
+    fun stopPolling() {
+        synchronized(this) {
+            stopPollingLocked()
+        }
+    }
+
+    internal fun readRuntimeConfig(context: Context): ZephyrOtaRuntimeConfig? {
+        val jsonString = try {
+            context.assets.open(CONFIG_FILE).bufferedReader().use { it.readText() }
+        } catch (_: Exception) {
+            return null
+        }
+
+        return try {
+            val json = JSONObject(jsonString)
+            ZephyrOtaRuntimeConfig(
+                enabled = json.optBoolean("enabled", false),
+                versionUrl = normalizeVersionUrl(json.optString("versionUrl").takeIf { it.isNotBlank() }),
+                pollingEnabled = json.optJSONObject("polling")?.optBoolean("enabled", true) ?: true,
+                pollingIntervalMs = json.optJSONObject("polling")?.optLong("intervalMs", DEFAULT_INTERVAL_MS)
+                    ?: DEFAULT_INTERVAL_MS,
+            )
+        } catch (error: Exception) {
+            Log.w(TAG, "Invalid Zephyr OTA config: ${error.message}")
+            null
+        }
+    }
+
+    internal fun fetchVersionInfo(baseUrl: String): ZephyrVersionInfo? {
+        val endpoint = toVersionInfoEndpoint(baseUrl)
+        val connection = (URL(endpoint).openConnection() as HttpURLConnection).apply {
+            requestMethod = "GET"
+            connectTimeout = 3_000
+            readTimeout = 3_000
+            setRequestProperty("Accept", "application/json")
+        }
+
+        return try {
+            val responseCode = connection.responseCode
+            if (responseCode !in 200..299) {
+                Log.w(TAG, "Version info request failed: $responseCode")
+                return null
+            }
+
+            val body = connection.inputStream.bufferedReader().use { stream -> stream.readText() }
+            parseVersionInfo(body, baseUrl)
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    internal fun parseVersionInfo(body: String, fallbackBaseUrl: String): ZephyrVersionInfo? {
+        val json = JSONObject(body)
+        val snapshotId = json.optString("snapshot_id", "").trim()
+        if (snapshotId.isEmpty()) {
+            return null
+        }
+
+        val versionUrl = normalizeVersionUrl(json.optString("version_url", fallbackBaseUrl))
+            ?: normalizeVersionUrl(fallbackBaseUrl)
+            ?: return null
+
+        return ZephyrVersionInfo(
+            snapshotId = snapshotId,
+            versionUrl = versionUrl,
+        )
+    }
+
+    internal fun normalizeVersionUrl(value: String?): String? {
+        val trimmed = value?.trim()
+        if (trimmed.isNullOrEmpty()) {
+            return null
+        }
+
+        val withoutTrailingSlash = trimmed.replace(Regex("/+$"), "")
+        if (withoutTrailingSlash.startsWith("http://", ignoreCase = true) ||
+            withoutTrailingSlash.startsWith("https://", ignoreCase = true)
+        ) {
+            return withoutTrailingSlash
+        }
+
+        return "https://${withoutTrailingSlash.trimStart('/')}"
+    }
+
+    internal fun toVersionInfoEndpoint(baseUrl: String): String {
+        return "${baseUrl.trimEnd('/')}/$VERSION_INFO_PATH"
+    }
+
+    internal fun joinBundleUrl(versionUrl: String?, bundle: String?): String? {
+        val normalizedBase = normalizeVersionUrl(versionUrl) ?: return null
+        val normalizedBundle = bundle
+            ?.trim()
+            ?.removePrefix("./")
+            ?.trimStart('/')
+            ?.takeIf { it.isNotEmpty() }
+            ?: return null
+        return "${normalizedBase.trimEnd('/')}/$normalizedBundle"
+    }
+
+    private fun isRemoteUrl(value: String): Boolean {
+        return value.startsWith("http://", ignoreCase = true) ||
+            value.startsWith("https://", ignoreCase = true)
+    }
+
+    internal fun shouldMarkUpdateReady(previousSnapshotId: String?, nextSnapshotId: String): Boolean {
+        val normalizedPrevious = previousSnapshotId?.trim()?.takeIf { it.isNotEmpty() } ?: return false
+        return normalizedPrevious != nextSnapshotId.trim()
+    }
+
+    private fun notifyUpdateReady(info: ZephyrVersionInfo) {
+        if (listeners.isEmpty()) {
+            return
+        }
+        mainHandler.post {
+            listeners.forEach { listener ->
+                listener.onUpdateReady(info)
+            }
+        }
+    }
+
+    private fun stopPollingLocked() {
+        pollingRunnable?.let(mainHandler::removeCallbacks)
+        pollingRunnable = null
+        pollingContext = null
+    }
+}

--- a/packages/sparkling-sdk/android/sparkling/src/test/java/com/tiktok/sparkling/ota/ZephyrOtaManagerTest.kt
+++ b/packages/sparkling-sdk/android/sparkling/src/test/java/com/tiktok/sparkling/ota/ZephyrOtaManagerTest.kt
@@ -1,0 +1,62 @@
+package com.tiktok.sparkling.ota
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ZephyrOtaManagerTest {
+
+  @Test
+  fun normalizeVersionUrlAddsHttpsWhenMissing() {
+    assertEquals(
+      "https://demo.zephyrcloud.app",
+      ZephyrOtaManager.normalizeVersionUrl("demo.zephyrcloud.app/")
+    )
+  }
+
+  @Test
+  fun joinBundleUrlNormalizesBundlePath() {
+    assertEquals(
+      "https://demo.zephyrcloud.app/main.lynx.bundle",
+      ZephyrOtaManager.joinBundleUrl("demo.zephyrcloud.app", "./main.lynx.bundle")
+    )
+  }
+
+  @Test
+  fun parseVersionInfoUsesReturnedVersionUrl() {
+    val info = ZephyrOtaManager.parseVersionInfo(
+      """{"version_url":"demo.zephyrcloud.app","snapshot_id":"snapshot-1"}""",
+      "https://fallback.zephyrcloud.app"
+    )
+
+    assertEquals("snapshot-1", info?.snapshotId)
+    assertEquals("https://demo.zephyrcloud.app", info?.versionUrl)
+  }
+
+  @Test
+  fun parseVersionInfoReturnsNullWithoutSnapshotId() {
+    val info = ZephyrOtaManager.parseVersionInfo(
+      """{"version_url":"demo.zephyrcloud.app"}""",
+      "https://fallback.zephyrcloud.app"
+    )
+
+    assertNull(info)
+  }
+
+  @Test
+  fun shouldMarkUpdateReadyWhenSnapshotChanges() {
+    assertTrue(ZephyrOtaManager.shouldMarkUpdateReady("snapshot-1", "snapshot-2"))
+  }
+
+  @Test
+  fun shouldNotMarkUpdateReadyOnFirstSnapshotSync() {
+    assertFalse(ZephyrOtaManager.shouldMarkUpdateReady(null, "snapshot-1"))
+  }
+
+  @Test
+  fun shouldNotMarkUpdateReadyWhenSnapshotStaysSame() {
+    assertFalse(ZephyrOtaManager.shouldMarkUpdateReady("snapshot-1", "snapshot-1"))
+  }
+}

--- a/packages/sparkling-sdk/ios/Sparkling/Application/Container/SPKContainerView+OTA.swift
+++ b/packages/sparkling-sdk/ios/Sparkling/Application/Container/SPKContainerView+OTA.swift
@@ -1,0 +1,154 @@
+// Copyright 2025 The Sparkling Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import Foundation
+import UIKit
+import SnapKit
+import ObjectiveC
+
+private var standaloneOtaControllerKey: UInt8 = 0
+
+final class SPKStandaloneOtaController {
+    weak var container: SPKContainerView?
+    weak var badge: UIButton?
+    var observer: NSObjectProtocol?
+
+    init(container: SPKContainerView) {
+        self.container = container
+    }
+
+    func sync() {
+        guard let container else {
+            return
+        }
+        guard !isManagedByViewController(container) else {
+            teardownBadge()
+            return
+        }
+        guard container.window != nil else {
+            teardownBadge()
+            SPKZephyrOTAManager.shared.stopPolling()
+            return
+        }
+        guard let config = SPKZephyrOTAManager.shared.readRuntimeConfig(),
+              config.enabled ?? false else {
+            teardownBadge()
+            return
+        }
+
+        installObserverIfNeeded()
+        installBadgeIfNeeded()
+        SPKZephyrOTAManager.shared.startPolling()
+        updateBadgeVisibility()
+    }
+
+    func cleanup() {
+        teardownBadge()
+        if let observer {
+            NotificationCenter.default.removeObserver(observer)
+            self.observer = nil
+        }
+    }
+
+    func installObserverIfNeeded() {
+        guard observer == nil else {
+            return
+        }
+        observer = NotificationCenter.default.addObserver(
+            forName: SPKZephyrOTAManager.updateReadyNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self else {
+                return
+            }
+            NSLog("SPKContainerView OTA update ready for container=%@", self.container?.containerID ?? "")
+            self.updateBadgeVisibility()
+        }
+    }
+
+    func installBadgeIfNeeded() {
+        guard let container else {
+            return
+        }
+        if let badge {
+            container.bringSubviewToFront(badge)
+            return
+        }
+
+        let button = UIButton(type: .system)
+        button.setTitle("Update ready · tap", for: .normal)
+        button.setTitleColor(.white, for: .normal)
+        button.backgroundColor = UIColor(white: 0.12, alpha: 0.92)
+        button.titleLabel?.font = UIFont.systemFont(ofSize: 12.0, weight: .semibold)
+        button.contentEdgeInsets = UIEdgeInsets(top: 6, left: 10, bottom: 6, right: 10)
+        button.layer.cornerRadius = 12.0
+        button.layer.masksToBounds = true
+        button.isHidden = true
+        button.addTarget(self, action: #selector(handleBadgeTap), for: .touchUpInside)
+        container.addSubview(button)
+        button.snp.makeConstraints { make in
+            make.top.equalTo(container.safeAreaLayoutGuide.snp.top).offset(12)
+            make.trailing.equalTo(container).offset(-16)
+        }
+        badge = button
+    }
+
+    func teardownBadge() {
+        badge?.removeFromSuperview()
+        badge = nil
+    }
+
+    func updateBadgeVisibility() {
+        let shouldShow = SPKZephyrOTAManager.shared.hasPendingUpdate()
+        badge?.isHidden = !shouldShow
+        if shouldShow, let badge, let container {
+            container.bringSubviewToFront(badge)
+        }
+    }
+
+    @objc
+    func handleBadgeTap() {
+        guard let container,
+              let originURL = container.originURL else {
+            return
+        }
+        guard SPKZephyrOTAManager.shared.applyPendingUpdateIfNeeded() else {
+            updateBadgeVisibility()
+            return
+        }
+
+        let reloadURL = container.config?.originURL ?? originURL
+        let context = container.context as? SPKContext ?? SPKContext()
+        let resolved = SPKScheme.resolver(withScheme: reloadURL, context: context, paramClass: SPKSchemeParam.self)
+        NSLog("SPKContainerView applying OTA: origin=%@ reload=%@ resolved=%@",
+              originURL.absoluteString,
+              reloadURL.absoluteString,
+              resolved?.resolvedURL?.absoluteString ?? "nil")
+        container.load(withParams: resolved ?? SPKSchemeParam.resolver(withScheme: reloadURL, context: context), context, forceInitKitView: false)
+        updateBadgeVisibility()
+    }
+
+    func isManagedByViewController(_ container: SPKContainerView) -> Bool {
+        var responder: UIResponder? = container
+        while let current = responder {
+            if current is SPKViewController {
+                return true
+            }
+            responder = current.next
+        }
+        return false
+    }
+}
+
+extension SPKContainerView {
+    var spk_standaloneOtaController: SPKStandaloneOtaController {
+        if let controller = objc_getAssociatedObject(self, &standaloneOtaControllerKey) as? SPKStandaloneOtaController {
+            return controller
+        }
+        let controller = SPKStandaloneOtaController(container: self)
+        objc_setAssociatedObject(self, &standaloneOtaControllerKey, controller, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        return controller
+    }
+}

--- a/packages/sparkling-sdk/ios/Sparkling/Application/Container/SPKContainerView.swift
+++ b/packages/sparkling-sdk/ios/Sparkling/Application/Container/SPKContainerView.swift
@@ -5,6 +5,7 @@
 import UIKit
 import SnapKit
 import SparklingMethod
+import ObjectiveC
 
 /// A hybrid view container that manages different types of SPK content.
 /// 
@@ -184,6 +185,7 @@ open class SPKContainerView: UIView, SPKContainerProtocol {
     }
         
     deinit {
+        self.spk_standaloneOtaController.cleanup()
         let current = Date().timeIntervalSince1970 * 1000
         let stayDuration = current - self.initStartTimeStamp
         var metric: [String: AnyHashable] = [:]
@@ -234,6 +236,7 @@ open class SPKContainerView: UIView, SPKContainerProtocol {
         
         self.config = params as? SPKSchemeParam
         self.context = context
+        self.context?.schemeParams = self.config
         self.context?.originURL = self.originURL?.absoluteString
         
         self.addContainerDefaultGlobalProps()
@@ -249,6 +252,7 @@ open class SPKContainerView: UIView, SPKContainerProtocol {
             "status": "start",
             "engine_type": self.engineTypeString()
         ])
+        self.spk_standaloneOtaController.sync()
     }
     
     func engineTypeString() -> String {
@@ -291,6 +295,11 @@ open class SPKContainerView: UIView, SPKContainerProtocol {
             return
         }
         self.kitView?.triggerLayout?()
+    }
+
+    public override func didMoveToWindow() {
+        super.didMoveToWindow()
+        self.spk_standaloneOtaController.sync()
     }
         
     /// Loads the hybrid engine with the configured parameters.

--- a/packages/sparkling-sdk/ios/Sparkling/Application/Container/SPKViewController.swift
+++ b/packages/sparkling-sdk/ios/Sparkling/Application/Container/SPKViewController.swift
@@ -7,6 +7,187 @@ import SnapKit
 import SparklingMethod
 import UIKit
 
+final class SPKDefaultLoadErrorView: UIView, SPKLoadErrorViewProtocol {
+    private let titleLabel = UILabel()
+    private let detailLabel = UILabel()
+    private let retryButton = UIButton(type: .system)
+    private var refreshBlock: SPKLoadErrorRefreshBlock?
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.backgroundColor = .white
+
+        self.titleLabel.text = "Load failed"
+        self.titleLabel.font = UIFont.systemFont(ofSize: 20.0, weight: .semibold)
+        self.titleLabel.textColor = .black
+        self.titleLabel.textAlignment = .center
+
+        self.detailLabel.font = UIFont.systemFont(ofSize: 13.0, weight: .regular)
+        self.detailLabel.textColor = UIColor(white: 0.25, alpha: 1.0)
+        self.detailLabel.textAlignment = .center
+        self.detailLabel.numberOfLines = 0
+
+        self.retryButton.setTitle("Retry", for: .normal)
+        self.retryButton.titleLabel?.font = UIFont.systemFont(ofSize: 15.0, weight: .semibold)
+        self.retryButton.backgroundColor = UIColor(white: 0.12, alpha: 0.92)
+        self.retryButton.setTitleColor(.white, for: .normal)
+        self.retryButton.contentEdgeInsets = UIEdgeInsets(top: 10, left: 16, bottom: 10, right: 16)
+        self.retryButton.layer.cornerRadius = 12.0
+        self.retryButton.addTarget(self, action: #selector(handleRetryTap), for: .touchUpInside)
+
+        let stack = UIStackView(arrangedSubviews: [self.titleLabel, self.detailLabel, self.retryButton])
+        stack.axis = .vertical
+        stack.alignment = .center
+        stack.spacing = 12.0
+
+        self.addSubview(stack)
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            stack.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+            stack.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+            stack.leadingAnchor.constraint(greaterThanOrEqualTo: self.leadingAnchor, constant: 24),
+            stack.trailingAnchor.constraint(lessThanOrEqualTo: self.trailingAnchor, constant: -24),
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func register(refreshBlock: @escaping SPKLoadErrorRefreshBlock) {
+        self.refreshBlock = refreshBlock
+    }
+
+    func container(_ contianer: SPKContainerProtocol, didReceiveError error: Error?) {
+        self.detailLabel.text = error?.localizedDescription ?? "Unknown error"
+    }
+
+    @objc private func handleRetryTap() {
+        self.refreshBlock?()
+    }
+}
+
+final class SPKGlobalOTABadgeController: NSObject {
+    static let shared = SPKGlobalOTABadgeController()
+
+    private var badgeButton: UIButton?
+    private var didRegisterObservers = false
+
+    func start() {
+        DispatchQueue.main.async {
+            self.registerObserversIfNeeded()
+            self.attachIfNeeded()
+            self.refresh()
+        }
+    }
+
+    func refresh() {
+        DispatchQueue.main.async {
+            self.attachIfNeeded()
+            let shouldShow = SPKZephyrOTAManager.shared.hasPendingUpdate()
+            self.badgeButton?.isHidden = !shouldShow
+            if shouldShow, let badgeButton = self.badgeButton, let superview = badgeButton.superview {
+                superview.bringSubviewToFront(badgeButton)
+            }
+        }
+    }
+
+    private func registerObserversIfNeeded() {
+        guard !self.didRegisterObservers else {
+            return
+        }
+        self.didRegisterObservers = true
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(handleUpdateReady(_:)),
+                                               name: SPKZephyrOTAManager.updateReadyNotification,
+                                               object: nil)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(handleDidBecomeActive),
+                                               name: UIApplication.didBecomeActiveNotification,
+                                               object: nil)
+    }
+
+    private func attachIfNeeded() {
+        guard let window = UIApplication.spk.mainWindow else {
+            return
+        }
+        if self.badgeButton?.superview === window {
+            return
+        }
+
+        let badgeButton = self.badgeButton ?? {
+            let button = UIButton(type: .system)
+            button.setTitle("Update ready · tap", for: .normal)
+            button.setTitleColor(.white, for: .normal)
+            button.backgroundColor = UIColor(white: 0.12, alpha: 0.92)
+            button.titleLabel?.font = UIFont.systemFont(ofSize: 12.0, weight: .semibold)
+            button.contentEdgeInsets = UIEdgeInsets(top: 6, left: 10, bottom: 6, right: 10)
+            button.layer.cornerRadius = 12.0
+            button.layer.masksToBounds = true
+            button.isHidden = true
+            button.translatesAutoresizingMaskIntoConstraints = false
+            button.addTarget(self, action: #selector(handleBadgeTap), for: .touchUpInside)
+            return button
+        }()
+
+        self.badgeButton = badgeButton
+        badgeButton.removeFromSuperview()
+        window.addSubview(badgeButton)
+        NSLayoutConstraint.activate([
+            badgeButton.topAnchor.constraint(equalTo: window.safeAreaLayoutGuide.topAnchor, constant: 12),
+            badgeButton.trailingAnchor.constraint(equalTo: window.trailingAnchor, constant: -16),
+        ])
+    }
+
+    @objc private func handleUpdateReady(_ notification: Notification) {
+        self.refresh()
+    }
+
+    @objc private func handleDidBecomeActive() {
+        self.refresh()
+    }
+
+    @objc private func handleBadgeTap() {
+        guard let viewController = Self.activeSparklingViewController() else {
+            NSLog("SPKGlobalOTABadgeController tap ignored: no active SPKViewController")
+            return
+        }
+        viewController.applyPendingOtaUpdate()
+        self.refresh()
+    }
+
+    private static func activeSparklingViewController() -> SPKViewController? {
+        return findSparklingViewController(from: UIApplication.spk.mainWindow?.rootViewController)
+    }
+
+    private static func findSparklingViewController(from controller: UIViewController?) -> SPKViewController? {
+        guard let controller else {
+            return nil
+        }
+        if let sparklingController = controller as? SPKViewController {
+            return sparklingController
+        }
+        if let presented = controller.presentedViewController,
+           let sparklingController = findSparklingViewController(from: presented) {
+            return sparklingController
+        }
+        if let navigationController = controller as? UINavigationController,
+           let sparklingController = findSparklingViewController(from: navigationController.visibleViewController ?? navigationController.viewControllers.last) {
+            return sparklingController
+        }
+        if let tabBarController = controller as? UITabBarController,
+           let sparklingController = findSparklingViewController(from: tabBarController.selectedViewController) {
+            return sparklingController
+        }
+        for child in controller.children.reversed() {
+            if let sparklingController = findSparklingViewController(from: child) {
+                return sparklingController
+            }
+        }
+        return nil
+    }
+}
+
 /// A view controller that manages SPK hybrid content with navigation and lifecycle support.
 /// 
 /// This class provides a complete container for hybrid content, handling navigation bars,
@@ -138,6 +319,7 @@ open class SPKViewController: UIViewController, SPKContainerProtocol {
     /// 
     /// This property stores the initial URL for reference and potential reloading scenarios.
     public var originURL: URL?
+    private var otaReloadURL: URL?
     
     /// The type of hybrid engine being used for content rendering.
     /// 
@@ -232,7 +414,6 @@ open class SPKViewController: UIViewController, SPKContainerProtocol {
     /// This optional view provides a custom background for the status bar area
     /// when needed for design consistency.
     var statusBarBackgroundView: UIView?
-    
     var originNavigationBarHidden: Bool = false
     var originNavigationBarIsHidden: Bool = false
     var originControllerPopGestureRecongnizerEnabled: Bool = false
@@ -270,6 +451,7 @@ open class SPKViewController: UIViewController, SPKContainerProtocol {
         let config = config ?? SPKScheme.resolver(withScheme: url, context: context, paramClass: SPKSchemeParam.self) as? SPKSchemeParam
         self.containerFrame = frame
         self.originURL = url
+        self.otaReloadURL = config?.originURL ?? url
         self.config = config
         self.statusBarStyle = config?.statusFontMode ?? self.statusBarStyle
         self.statusBarHiddenStatus = config?.hideStatusBar ?? self.statusBarHiddenStatus
@@ -312,6 +494,8 @@ open class SPKViewController: UIViewController, SPKContainerProtocol {
         self.load(withURL: self.originURL)
         
         self.setupNotification()
+        SPKZephyrOTAManager.shared.startPolling()
+        SPKGlobalOTABadgeController.shared.start()
         self.containerLifecycleDelegate?.containerViewDidLoad?(self)
     }
     
@@ -345,6 +529,10 @@ open class SPKViewController: UIViewController, SPKContainerProtocol {
                                                selector: #selector(handleResignActive),
                                                name: UIApplication.willResignActiveNotification,
                                                object: nil)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(handleOtaUpdateReady(_:)),
+                                               name: SPKZephyrOTAManager.updateReadyNotification,
+                                               object: nil)
     }
     
     /// Called when the view is about to appear.
@@ -374,6 +562,8 @@ open class SPKViewController: UIViewController, SPKContainerProtocol {
     /// - Parameter animated: Whether the appearance was animated
     public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        SPKZephyrOTAManager.shared.startPolling()
+        SPKGlobalOTABadgeController.shared.start()
         self.oldDelegate = self.navigationController?.interactivePopGestureRecognizer?.delegate
         self.navigationController?.interactivePopGestureRecognizer?.delegate = self
         self.originControllerPopGestureRecongnizerEnabled = self.navigationController?.interactivePopGestureRecognizer?.isEnabled ?? self.originControllerPopGestureRecongnizerEnabled
@@ -548,7 +738,7 @@ open class SPKViewController: UIViewController, SPKContainerProtocol {
             })
         }
     }
-    
+
     /// Generates and configures a new navigation bar instance.
     /// 
     /// This method creates a navigation bar with proper button handlers,
@@ -587,6 +777,36 @@ open class SPKViewController: UIViewController, SPKContainerProtocol {
             navigationBar.update?(backgroundColor: navBarColor)
         }
         return navigationBar
+    }
+
+    @objc private func handleOtaUpdateReady(_ notification: Notification) {
+        NSLog("SPKViewController OTA update ready for container=%@", self.containerID)
+        SPKGlobalOTABadgeController.shared.refresh()
+    }
+
+    @objc private func handleOtaBadgeTap() {
+        self.applyPendingOtaUpdate()
+    }
+
+    func applyPendingOtaUpdate() {
+        guard let originURL = self.originURL else {
+            return
+        }
+        guard SPKZephyrOTAManager.shared.applyPendingUpdateIfNeeded() else {
+            SPKGlobalOTABadgeController.shared.refresh()
+            return
+        }
+        let reloadURL = self.otaReloadURL ?? originURL
+        let context = self.context as? SPKContext ?? SPKContext()
+        let resolved = SPKScheme.resolver(withScheme: reloadURL, context: context, paramClass: SPKSchemeParam.self)
+        NSLog("SPKViewController applying OTA: origin=%@ reload=%@ resolved=%@",
+              originURL.absoluteString,
+              reloadURL.absoluteString,
+              resolved?.resolvedURL?.absoluteString ?? "nil")
+        self.config = resolved
+        self.context = context
+        self.viewContainer?.load(withParams: resolved ?? SPKSchemeParam.resolver(withScheme: reloadURL, context: context), context, forceInitKitView: true)
+        SPKGlobalOTABadgeController.shared.refresh()
     }
     
     /// Handles the left button (back button) tap event.
@@ -765,6 +985,7 @@ open class SPKViewController: UIViewController, SPKContainerProtocol {
         }
         
         self.originURL = self.originURL ?? url
+        self.otaReloadURL = self.otaReloadURL ?? config.originURL ?? url
         self.viewContainer?.load(withParams: config, self.context)
     }
     
@@ -867,6 +1088,9 @@ extension SPKViewController: SPKContainerLifecycleProtocol {
     }
     
     public func container(_ container: any SPKContainerProtocol, didLoadFailedWithURL url: URL?, error: (any Error)?) {
+        NSLog("SPKViewController load failed: url=%@ error=%@",
+              url?.absoluteString ?? "nil",
+              error?.localizedDescription ?? "nil")
         if self.viewContainer?.shouldShowLoadFailedView(with: error) == true {
             self.addLoadFailedView(error)
         }
@@ -896,16 +1120,16 @@ extension SPKViewController: SPKContainerLifecycleProtocol {
     
     func buildLoadErrorView() -> (UIView & SPKLoadErrorViewProtocol)? {
         guard let context = self.context as? SPKContext else {
-            return nil
+            return SPKDefaultLoadErrorView()
         }
         
-        let loadFailedView = context.loadFailedView ?? context.failedViewBuilder?(self)
+        let loadFailedView = context.loadFailedView ?? context.failedViewBuilder?(self) ?? SPKDefaultLoadErrorView()
         
-        loadFailedView?.register?(refreshBlock: { [weak self] in
+        loadFailedView.register?(refreshBlock: { [weak self] in
             self?.handleErrorViewReload()
         })
         
-        return nil
+        return loadFailedView
     }
     
     func handleErrorViewReload() {

--- a/packages/sparkling-sdk/ios/Sparkling/Application/OTA/SPKZephyrOTAManager.swift
+++ b/packages/sparkling-sdk/ios/Sparkling/Application/OTA/SPKZephyrOTAManager.swift
@@ -1,0 +1,295 @@
+// Copyright 2025 The Sparkling Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import Foundation
+
+struct SPKZephyrOTARuntimeConfig: Decodable {
+    struct Polling: Decodable {
+        let enabled: Bool?
+        let intervalMs: Double?
+    }
+
+    let enabled: Bool?
+    let versionUrl: String?
+    let polling: Polling?
+}
+
+struct SPKZephyrVersionInfo {
+    let snapshotId: String
+    let versionUrl: String
+}
+
+final class SPKZephyrOTAManager {
+    static let updateReadyNotification = Notification.Name("com.tiktok.sparkling.zephyr-ota.update-ready")
+    static let shared = SPKZephyrOTAManager()
+
+    private let defaults = UserDefaults.standard
+    private let queue = DispatchQueue(label: "com.tiktok.sparkling.zephyr-ota", qos: .utility)
+    private let decoder = JSONDecoder()
+
+    private let configFileName = "sparkling.zephyr.json"
+    private let versionInfoPath = "__get_version_info__"
+    private let defaultPollingIntervalMs = 15 * 60 * 1000.0
+    private let minimumPollingIntervalMs = 1_000.0
+    private let appliedSnapshotIdKey = "sparkling_zephyr_ota.applied_snapshot_id"
+    private let appliedVersionUrlKey = "sparkling_zephyr_ota.applied_version_url"
+    private let pendingSnapshotIdKey = "sparkling_zephyr_ota.pending_snapshot_id"
+    private let pendingVersionUrlKey = "sparkling_zephyr_ota.pending_version_url"
+    private let pendingUpdateAvailableKey = "sparkling_zephyr_ota.pending_update_available"
+    private let lastCheckAtKey = "sparkling_zephyr_ota.last_check_at"
+
+    private var refreshInFlight = false
+    private var pollingTimer: DispatchSourceTimer?
+    private var pollingIntervalMs: Double?
+
+    private init() {}
+
+    private func stopPollingLocked() {
+        pollingTimer?.cancel()
+        pollingTimer = nil
+        pollingIntervalMs = nil
+    }
+
+    func resolveBundle(_ bundle: String?) -> String? {
+        guard let bundle, !bundle.isEmpty else {
+            return bundle
+        }
+        if Self.isRemoteUrl(bundle) {
+            return bundle
+        }
+
+        guard let config = readRuntimeConfig(), config.enabled ?? false else {
+            return bundle
+        }
+
+        return Self.joinBundleUrl(baseUrl: defaults.string(forKey: appliedVersionUrlKey), bundle: bundle) ?? bundle
+    }
+
+    func hasPendingUpdate() -> Bool {
+        return defaults.bool(forKey: pendingUpdateAvailableKey)
+    }
+
+    @discardableResult
+    func applyPendingUpdateIfNeeded() -> Bool {
+        guard defaults.bool(forKey: pendingUpdateAvailableKey),
+              let snapshotId = defaults.string(forKey: pendingSnapshotIdKey),
+              let versionUrl = defaults.string(forKey: pendingVersionUrlKey) else {
+            return false
+        }
+
+        defaults.set(snapshotId, forKey: appliedSnapshotIdKey)
+        defaults.set(versionUrl, forKey: appliedVersionUrlKey)
+        defaults.removeObject(forKey: pendingSnapshotIdKey)
+        defaults.removeObject(forKey: pendingVersionUrlKey)
+        defaults.set(false, forKey: pendingUpdateAvailableKey)
+        return true
+    }
+
+    func refreshIfNeeded(force: Bool = false) {
+        guard let config = readRuntimeConfig(),
+              config.enabled ?? false,
+              config.polling?.enabled ?? true,
+              let versionUrl = Self.normalizeVersionUrl(config.versionUrl) else {
+            return
+        }
+
+        let now = Date().timeIntervalSince1970 * 1000
+        let lastCheckAt = defaults.double(forKey: lastCheckAtKey)
+        let intervalMs = config.polling?.intervalMs ?? defaultPollingIntervalMs
+        if !force, now - lastCheckAt < max(intervalMs, 0) {
+            return
+        }
+
+        queue.async {
+            if self.refreshInFlight {
+                return
+            }
+            self.refreshInFlight = true
+            self.defaults.set(now, forKey: self.lastCheckAtKey)
+            defer {
+                self.refreshInFlight = false
+            }
+
+            do {
+                guard let versionInfo = try self.fetchVersionInfo(baseUrl: versionUrl) else {
+                    return
+                }
+                let appliedSnapshotId = self.defaults.string(forKey: self.appliedSnapshotIdKey)
+                let pendingSnapshotId = self.defaults.string(forKey: self.pendingSnapshotIdKey)
+                let normalizedNextSnapshotId = versionInfo.snapshotId.trimmingCharacters(in: .whitespacesAndNewlines)
+
+                let shouldNotify: Bool
+                if appliedSnapshotId?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false {
+                    self.defaults.set(normalizedNextSnapshotId, forKey: self.appliedSnapshotIdKey)
+                    self.defaults.set(versionInfo.versionUrl, forKey: self.appliedVersionUrlKey)
+                    self.defaults.removeObject(forKey: self.pendingSnapshotIdKey)
+                    self.defaults.removeObject(forKey: self.pendingVersionUrlKey)
+                    self.defaults.set(false, forKey: self.pendingUpdateAvailableKey)
+                    shouldNotify = false
+                } else if Self.shouldMarkUpdateReady(previousSnapshotId: appliedSnapshotId, nextSnapshotId: normalizedNextSnapshotId) {
+                    self.defaults.set(normalizedNextSnapshotId, forKey: self.pendingSnapshotIdKey)
+                    self.defaults.set(versionInfo.versionUrl, forKey: self.pendingVersionUrlKey)
+                    self.defaults.set(true, forKey: self.pendingUpdateAvailableKey)
+                    shouldNotify = pendingSnapshotId?.trimmingCharacters(in: .whitespacesAndNewlines) != normalizedNextSnapshotId
+                } else {
+                    self.defaults.removeObject(forKey: self.pendingSnapshotIdKey)
+                    self.defaults.removeObject(forKey: self.pendingVersionUrlKey)
+                    self.defaults.set(false, forKey: self.pendingUpdateAvailableKey)
+                    shouldNotify = false
+                }
+                self.defaults.set(Date().timeIntervalSince1970 * 1000, forKey: self.lastCheckAtKey)
+                NSLog("SPKZephyrOTAManager refresh: applied=%@ pending=%@ next=%@ shouldNotify=%@ versionUrl=%@",
+                      appliedSnapshotId ?? "nil",
+                      pendingSnapshotId ?? "nil",
+                      versionInfo.snapshotId,
+                      shouldNotify.description,
+                      versionInfo.versionUrl)
+                if shouldNotify {
+                    DispatchQueue.main.async {
+                        NotificationCenter.default.post(name: Self.updateReadyNotification, object: versionInfo)
+                    }
+                }
+            } catch {
+                NSLog("SPKZephyrOTAManager refresh failed: %@", error.localizedDescription)
+            }
+        }
+    }
+
+    func startPolling() {
+        guard let config = readRuntimeConfig(),
+              config.enabled ?? false,
+              config.polling?.enabled ?? true else {
+            stopPolling()
+            return
+        }
+
+        let intervalMs = max(config.polling?.intervalMs ?? defaultPollingIntervalMs, minimumPollingIntervalMs)
+        queue.async {
+            if let currentInterval = self.pollingIntervalMs,
+               abs(currentInterval - intervalMs) < 0.0001,
+               self.pollingTimer != nil {
+                self.refreshIfNeeded(force: true)
+                return
+            }
+
+            self.stopPollingLocked()
+            self.pollingIntervalMs = intervalMs
+            let timer = DispatchSource.makeTimerSource(queue: self.queue)
+            timer.schedule(deadline: .now(), repeating: .milliseconds(Int(intervalMs)))
+            timer.setEventHandler { [weak self] in
+                self?.refreshIfNeeded(force: true)
+            }
+            self.pollingTimer = timer
+            timer.resume()
+        }
+    }
+
+    func stopPolling() {
+        queue.async {
+            self.stopPollingLocked()
+        }
+    }
+
+    func readRuntimeConfig() -> SPKZephyrOTARuntimeConfig? {
+        guard let configURL = findConfigURL(),
+              let data = try? Data(contentsOf: configURL) else {
+            return nil
+        }
+
+        return try? decoder.decode(SPKZephyrOTARuntimeConfig.self, from: data)
+    }
+
+    func fetchVersionInfo(baseUrl: String) throws -> SPKZephyrVersionInfo? {
+        let endpoint = Self.versionInfoEndpoint(baseUrl: baseUrl)
+        let data = try Data(contentsOf: endpoint)
+        return try parseVersionInfo(data: data, fallbackBaseUrl: baseUrl)
+    }
+
+    func parseVersionInfo(data: Data, fallbackBaseUrl: String) throws -> SPKZephyrVersionInfo? {
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let snapshotId = (json?["snapshot_id"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !snapshotId.isEmpty else {
+            return nil
+        }
+
+        let rawVersionUrl = json?["version_url"] as? String
+        guard let versionUrl = Self.normalizeVersionUrl(rawVersionUrl) ?? Self.normalizeVersionUrl(fallbackBaseUrl) else {
+            return nil
+        }
+
+        return SPKZephyrVersionInfo(
+            snapshotId: snapshotId,
+            versionUrl: versionUrl
+        )
+    }
+
+    private func findConfigURL() -> URL? {
+        guard let root = Bundle.main.resourceURL else {
+            return nil
+        }
+
+        let prefixes = ["LynxResources/Assets", "LynxResources", "Assets", ""]
+        for prefix in prefixes {
+            let candidate = prefix.isEmpty
+                ? root.appendingPathComponent(configFileName)
+                : root.appendingPathComponent(prefix).appendingPathComponent(configFileName)
+            if FileManager.default.fileExists(atPath: candidate.path) {
+                return candidate
+            }
+        }
+
+        return Bundle.main.url(forResource: "sparkling.zephyr", withExtension: "json")
+    }
+
+    static func normalizeVersionUrl(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+
+        let withoutTrailingSlash = trimmed.replacingOccurrences(of: "/+$", with: "", options: .regularExpression)
+        if withoutTrailingSlash.lowercased().hasPrefix("http://") || withoutTrailingSlash.lowercased().hasPrefix("https://") {
+            return withoutTrailingSlash
+        }
+
+        let withoutLeadingSlash = withoutTrailingSlash.replacingOccurrences(of: "^/+", with: "", options: .regularExpression)
+        return "https://\(withoutLeadingSlash)"
+    }
+
+    static func versionInfoEndpoint(baseUrl: String) -> URL {
+        let normalized = baseUrl.replacingOccurrences(of: "/+$", with: "", options: .regularExpression)
+        return URL(string: "\(normalized)/__get_version_info__")!
+    }
+
+    static func joinBundleUrl(baseUrl: String?, bundle: String?) -> String? {
+        guard let normalizedBase = normalizeVersionUrl(baseUrl),
+              let rawBundle = bundle?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !rawBundle.isEmpty else {
+            return nil
+        }
+
+        let normalizedBundle = rawBundle
+            .replacingOccurrences(of: "^\\./", with: "", options: .regularExpression)
+            .replacingOccurrences(of: "^/+", with: "", options: .regularExpression)
+
+        guard !normalizedBundle.isEmpty else {
+            return nil
+        }
+
+        return "\(normalizedBase)/\(normalizedBundle)"
+    }
+
+    static func isRemoteUrl(_ value: String) -> Bool {
+        let lowercased = value.lowercased()
+        return lowercased.hasPrefix("http://") || lowercased.hasPrefix("https://")
+    }
+
+    static func shouldMarkUpdateReady(previousSnapshotId: String?, nextSnapshotId: String) -> Bool {
+        guard let previousSnapshotId = previousSnapshotId?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !previousSnapshotId.isEmpty else {
+            return false
+        }
+        return previousSnapshotId != nextSnapshotId.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/packages/sparkling-sdk/ios/Sparkling/Application/Scheme/SPKScheme.swift
+++ b/packages/sparkling-sdk/ios/Sparkling/Application/Scheme/SPKScheme.swift
@@ -73,6 +73,12 @@ open class SPKScheme: NSObject, SPKSchemeProtocol {
             return nil
         }
 
+        // Prefer the already-flattened inner query map from the resolved params.
+        // Using the outer `resolvedURL` query map here re-wraps `url=hybrid://...`
+        // and can clobber the actual remote bundle URL during OTA apply.
+        extra = parsedParams.extra.reduce(into: [String: String]()) { partialResult, item in
+            partialResult[item.key] = "\(item.value)"
+        }
         parsedParams.update(withDictionary: extra)
         
         extra?.updateValue(parsedParams.resolvedURL?.absoluteString ?? "", forKey: "resolvedURL")

--- a/packages/sparkling-sdk/ios/Sparkling/Service/Base/SPKHybridSchemeParam.swift
+++ b/packages/sparkling-sdk/ios/Sparkling/Service/Base/SPKHybridSchemeParam.swift
@@ -124,6 +124,12 @@ open class SPKHybridSchemeParam: NSObject {
         var newExtraDict = self.extra
 
         newExtraDict.merge(newParam.extra) { _, new in new }
+        if newParam.extra["url"] != nil && newParam.extra["bundle"] == nil {
+            newExtraDict.removeValue(forKey: "bundle")
+        }
+        if newParam.extra["bundle"] != nil && newParam.extra["url"] == nil {
+            newExtraDict.removeValue(forKey: "url")
+        }
         
         self.update(withDictionary: newExtraDict)
         self.originURL = newParam.originURL
@@ -182,7 +188,9 @@ open class SPKHybridSchemeParam: NSObject {
         let scheme = String("hybrid://hybrid")
         var dict: [String: String] = [:]
         dict.updateValue(innerScheme?.absoluteString ?? "", forKey: "url")
-        
+        let resolvedQueries = innerScheme?.spk.decodedQueryItems ?? queries
+        param.update(withDictionary: resolvedQueries, context: context)
+
         let resolvedScheme = URL.spk.url(string: scheme)?.spk.merging(queries: dict, encode: true)
         param.resolvedURL = resolvedScheme
         param.originURL = orignalURL
@@ -235,7 +243,15 @@ open class SPKHybridSchemeParam: NSObject {
         }
         
         var innerParams: [String: Any] = URL.spk.url(string: innerUrl)?.spk.decodedQueryItems ?? [:]
-        innerParams.merge(dict, uniquingKeysWith: { _, new in new})
+        let isWrappedHybridUrl = URL.spk.url(string: innerUrl)?.scheme == "hybrid"
+        var outerParams = dict
+        if isWrappedHybridUrl {
+            // OTA resolution wraps the actual Lynx params inside `url=hybrid://lynxview?...`.
+            // Keep the flattened inner query map as source of truth; otherwise the outer
+            // wrapper overwrites `url=https://...bundle` with `url=hybrid://lynxview?...`.
+            outerParams.removeValue(forKey: "url")
+        }
+        innerParams.merge(outerParams, uniquingKeysWith: { _, new in new})
         return innerParams
     }
     
@@ -249,10 +265,7 @@ open class SPKHybridSchemeParam: NSObject {
 
     static public func resolveURLStyle(toHybridScheme originURL: URL?, queries: [String: String]?) -> URL? {
         if originURL?.host?.contains("lynx") == true {
-            let url = queries?.spk.string(forKey: "url") ?? ""
-            var lynxQuery = queries
-            lynxQuery?.removeValue(forKey: "url")
-            let resolved = URL.spk.url(string: "hybrid://lynxview", queryItems: lynxQuery)
+            let resolved = URL.spk.url(string: "hybrid://lynxview", queryItems: queries)
             return resolved
         } else if originURL?.host?.contains("webview") == true {
             let baseUrl = String("hybrid://webview")
@@ -264,6 +277,16 @@ open class SPKHybridSchemeParam: NSObject {
     
     static public func resolveBundleStyle(toHybridScheme originURL: URL?, queries: [String: String]?) -> URL? {
         let bundle = queries?.spk.string(forKey: "bundle") ?? ""
+        let resolvedBundle = SPKZephyrOTAManager.shared.resolveBundle(bundle)
+        SPKZephyrOTAManager.shared.refreshIfNeeded()
+
+        if let resolvedBundle, SPKZephyrOTAManager.isRemoteUrl(resolvedBundle) {
+            var lynxQuery = queries ?? [:]
+            lynxQuery.removeValue(forKey: "bundle")
+            lynxQuery.updateValue(resolvedBundle, forKey: "url")
+            return URL.spk.url(string: "hybrid://lynxview", queryItems: lynxQuery)
+        }
+
         let baseURL = "hybrid://lynxview?bundle=\(bundle)"
         var lynxQuery = queries ?? [:]
         lynxQuery.removeValue(forKey: "bundle")

--- a/packages/sparkling-sdk/ios/Sparkling/Service/LynxService/SPKWrapperLynxView.swift
+++ b/packages/sparkling-sdk/ios/Sparkling/Service/LynxService/SPKWrapperLynxView.swift
@@ -327,6 +327,9 @@ open class SPKWrapperLynxView: LynxView, SPKWrapperLynxViewProtocol {
         }
 
         if var sourceUrl = params.sourceUrl {
+            NSLog("SPKWrapperLynxView load: sourceUrl=%@ fullURL=%@",
+                  sourceUrl,
+                  params.context?.fullURL ?? "nil")
             self.loadTemplate(fromURL: sourceUrl, initData: initialData)
         }
     }
@@ -446,6 +449,7 @@ extension SPKWrapperLynxView: LynxViewLifecycle {
     }
     
     public func lynxView(_ view: LynxView!, didLoadFinishedWithUrl url: String!) {
+        NSLog("SPKWrapperLynxView didLoadFinishedWithUrl: %@", url ?? "nil")
         self.loadState = .SPKLoadStateSucceed
         self.estimatedProgress = Float(1)
         DispatchQueue.spk.asyncMain { [weak self] in
@@ -475,6 +479,7 @@ extension SPKWrapperLynxView: LynxViewLifecycle {
     }
     
     public func lynxView(_ view: LynxView!, didRecieveError error: (any Error)!) {
+        NSLog("SPKWrapperLynxView didReceiveError: %@", error?.localizedDescription ?? "nil")
         DispatchQueue.spk.asyncMain { [weak self] in
             self?.lifeCycleDelegate?.view?(self, didReceiveError: error)
         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,7 +38,7 @@ importers:
         version: 29.7.0(@types/node@22.19.9)(ts-node@10.9.2(@types/node@22.19.9)(typescript@5.8.3))
       ts-jest:
         specifier: ^29.1.2
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.19.9)(ts-node@10.9.2(@types/node@22.19.9)(typescript@5.8.3)))(typescript@5.8.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -54,10 +54,10 @@ importers:
         version: 29.5.14
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.2.3)(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.8.3))
+        version: 29.7.0(@types/node@22.19.9)(ts-node@10.9.2(@types/node@22.19.9)(typescript@5.8.3))
       ts-jest:
         specifier: ^29.1.2
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@25.2.3)(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.8.3)))(typescript@5.8.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -73,10 +73,10 @@ importers:
         version: 29.5.14
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.2.3)(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.8.3))
+        version: 29.7.0(@types/node@22.19.9)(ts-node@10.9.2(@types/node@22.19.9)(typescript@5.8.3))
       ts-jest:
         specifier: ^29.1.2
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@25.2.3)(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.8.3)))(typescript@5.8.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -92,10 +92,10 @@ importers:
         version: 29.5.14
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.2.3)(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.8.3))
+        version: 29.7.0(@types/node@22.19.9)(ts-node@10.9.2(@types/node@22.19.9)(typescript@5.8.3))
       ts-jest:
         specifier: ^29.1.2
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@25.2.3)(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.8.3)))(typescript@5.8.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -181,6 +181,9 @@ importers:
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@22.19.9)(typescript@5.8.3)
+      zephyr-agent:
+        specifier: ^1.0.0
+        version: 1.0.0(https-proxy-agent@7.0.6)
     devDependencies:
       '@types/fs-extra':
         specifier: ^11.0.4
@@ -199,7 +202,7 @@ importers:
         version: 29.7.0(@types/node@22.19.9)(ts-node@10.9.2(@types/node@22.19.9)(typescript@5.8.3))
       ts-jest:
         specifier: ^29.4.6
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.19.9)(ts-node@10.9.2(@types/node@22.19.9)(typescript@5.8.3)))(typescript@5.8.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -256,7 +259,7 @@ importers:
         version: 29.7.0(@types/node@22.19.9)(ts-node@10.9.2(@types/node@22.19.9)(typescript@5.8.3))
       ts-jest:
         specifier: ^29.1.2
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.19.9)(ts-node@10.9.2(@types/node@22.19.9)(typescript@5.8.3)))(typescript@5.8.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0)(typescript@5.8.3)
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@22.19.9)(typescript@5.8.3)
@@ -1602,6 +1605,9 @@ packages:
     resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
     engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
 
+  '@toon-format/toon@0.9.0':
+    resolution: {integrity: sha512-BaMhGh1+/z8ceDrF2xL9Drd42hijbUJlivm/1goPR26RgCYsqlMkHbg48hx9a5UjZC7oZqxWPJ6ju5qvALi6Ag==}
+
   '@tsconfig/node10@1.0.12':
     resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
 
@@ -1989,6 +1995,11 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
+  axios-retry@4.5.0:
+    resolution: {integrity: sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==}
+    peerDependencies:
+      axios: 0.x || 1.x
+
   axios@1.13.5:
     resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
 
@@ -2083,6 +2094,10 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
+
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -2173,6 +2188,10 @@ packages:
 
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
+    engines: {node: '>=8'}
+
+  ci-info@4.4.0:
+    resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
 
   cjs-module-lexer@1.4.3:
@@ -2439,6 +2458,14 @@ packages:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
+    engines: {node: '>=18'}
+
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
@@ -2446,6 +2473,10 @@ packages:
   define-lazy-prop@2.0.0:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
     engines: {node: '>=8'}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
 
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
@@ -2672,6 +2703,14 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@4.1.0:
+    resolution: {integrity: sha512-2GuF51iuHX6A9xdTccMTsNb7VO0lHZihApxhvQzJB5A03DvHDd2FQepodbMaztPBmBcE/ox7o2gqaxGhYB9LhQ==}
+    engines: {node: '>=20.0.0'}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -2825,6 +2864,12 @@ packages:
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
+
+  git-up@7.0.0:
+    resolution: {integrity: sha512-ONdIrbBCFusq1Oy0sC71F5azx8bVkvtZtMJAsv+a6lz5YAmbNnLD6HAB4gptHZVLPR8S2/kVN6Gab7lryq5+lQ==}
+
+  git-url-parse@15.0.0:
+    resolution: {integrity: sha512-5reeBufLi+i4QD3ZFftcJs9jC26aULFLBU23FeKM/b1rI0K6ofIeAblmDVO7Ht22zTDE9+CkJ3ZVb0CgJmz3UQ==}
 
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
@@ -3042,6 +3087,10 @@ packages:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
 
+  is-ci@4.1.0:
+    resolution: {integrity: sha512-Ab9bQDQ11lWootZUI5qxgN2ZXwxNI5hTwnsvOc1wyxQ7zQ8OkEDw79mI0+9jI3x432NfwbVRru+3noJfXF6lSQ==}
+    hasBin: true
+
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
@@ -3060,6 +3109,11 @@ packages:
   is-docker@2.2.1:
     resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
     engines: {node: '>=8'}
+    hasBin: true
+
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
 
   is-extendable@0.1.1:
@@ -3093,6 +3147,11 @@ packages:
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
+
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
     engines: {node: '>= 0.4'}
@@ -3120,6 +3179,10 @@ packages:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
 
+  is-retry-allowed@2.2.0:
+    resolution: {integrity: sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==}
+    engines: {node: '>=10'}
+
   is-set@2.0.3:
     resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
     engines: {node: '>= 0.4'}
@@ -3127,6 +3190,9 @@ packages:
   is-shared-array-buffer@1.0.4:
     resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
     engines: {node: '>= 0.4'}
+
+  is-ssh@1.4.1:
+    resolution: {integrity: sha512-JNeu1wQsHjyHgn9NcWTaXq6zWSR6hqE0++zhfZlkFBbScNkyvxCdeV8sRkSBaeLKxmbpR21brail63ACNxJ0Tg==}
 
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
@@ -3159,6 +3225,10 @@ packages:
   is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
     engines: {node: '>=8'}
+
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
 
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
@@ -3333,6 +3403,9 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
@@ -3744,6 +3817,10 @@ packages:
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
+  node-persist@4.0.4:
+    resolution: {integrity: sha512-8sPAz/7tw1mCCc8xBG4f0wi+flHkSSgQeX998iQ75Pu27evA6UUWCjSE7xnrYTg2q33oU5leJ061EKPDv6BocQ==}
+    engines: {node: '>=10.12.0'}
+
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
@@ -3811,6 +3888,10 @@ packages:
   oniguruma-to-es@4.3.4:
     resolution: {integrity: sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==}
 
+  open@10.2.0:
+    resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
+    engines: {node: '>=18'}
+
   open@8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
@@ -3844,6 +3925,12 @@ packages:
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
+
+  parse-path@7.1.0:
+    resolution: {integrity: sha512-EuCycjZtfPcjWk7KTksnJ5xPMvWGA/6i4zrLYhRG0hGvC3GPU/jGUj3Cy+ZR0v30duV3e23R95T1lE2+lsndSw==}
+
+  parse-url@8.1.0:
+    resolution: {integrity: sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==}
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
@@ -4103,8 +4190,14 @@ packages:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
 
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  protocols@2.0.2:
+    resolution: {integrity: sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==}
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
@@ -4277,6 +4370,10 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -4291,6 +4388,10 @@ packages:
 
   rslog@1.3.2:
     resolution: {integrity: sha512-1YyYXBvN0a2b1MSIDLwDTqqgjDzRKxUg/S/+KO6EAgbtZW1B3fdLHAMhEEtvk1patJYMqcRvlp3HQwnxj7AdGQ==}
+
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -4566,15 +4667,15 @@ packages:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
   sparkling-app-cli@2.1.0-rc.12:
-    resolution: {integrity: sha512-oGsasUhESjW5WyTmE5yzKfXQMnV0YEHQtyWzdRqYYafNogVS+XVHQY5rc2EPlkxCanAPURnBH+yGa9nGp3b8ng==}
+    resolution: {integrity: sha512-bGR7W5SmTCgQNQWA5b9vg7a9RleZisdxfonOR08UuBRtct71jh9KasQ3YRmJA3+81K9YxOxddiPSfJ+dPTqsyQ==}
     engines: {node: ^22 || ^24}
     hasBin: true
 
   sparkling-method@2.1.0-rc.12:
-    resolution: {integrity: sha512-si236UDJAHzduebu9GZk3Y1qOMZIOGG52c3c9zOxQgDbMoqTMCww0gndw+4PqleqCp04gglfbd+FCeosfrXcUw==}
+    resolution: {integrity: sha512-TfSMzFS66MYJWZG4Drn5gNCMtDqkJIvVNHhVu6DIyVxjFhIgdRiXqYsDwLh8VIQlHnTQnuNmONVEtHPzsEWaFw==}
 
   sparkling-navigation@2.1.0-rc.12:
-    resolution: {integrity: sha512-ok/Qx0LCyvI/0k6GsHoEHcoY2GWMkvYGqNjAfwnUwUfWuIIzgjBBt792oOUyRrXKQrQXpWEEu8oIxnNKb0msJw==}
+    resolution: {integrity: sha512-kAQ5jZsjAixrQuoCBiiojY4jNxyilrhP/ZAjg9DvCmqdOQME73rC1+BR8zax1cyxLeAaa0fxcztAS6exA78qnA==}
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -5257,6 +5358,10 @@ packages:
       utf-8-validate:
         optional: true
 
+  wsl-utils@0.1.0:
+    resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
+    engines: {node: '>=18'}
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -5291,6 +5396,14 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zephyr-agent@1.0.0:
+    resolution: {integrity: sha512-27FHvzY7TYdW5F7HJv1C/Xmtm6kZGzVjKbZ9Rzx4K6bFzTofzrW4ytYB03f8nNDJeVPCu/6UUDLMEJL+LeZyZQ==}
+    peerDependencies:
+      https-proxy-agent: ^7.0.6
+
+  zephyr-edge-contract@1.0.0:
+    resolution: {integrity: sha512-BUL7LNgKgKvDL2KtgN3KmkvdT0Yeto64qav04ZkIapTvGnIuBgHQcvNWQ5QMUk2v7sBBTFlzfVEwhVJ3FFfnfQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -5730,41 +5843,6 @@ snapshots:
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
       jest-config: 29.7.0(@types/node@22.19.9)(ts-node@10.9.2(@types/node@22.19.9)(typescript@5.8.3))
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.8
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.8.3))':
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 22.19.9
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.19.9)(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.8.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -6355,7 +6433,7 @@ snapshots:
       '@rsdoctor/sdk': 1.2.3(@rspack/core@1.7.5(@swc/helpers@0.5.18))(webpack@5.105.0)
       '@rsdoctor/types': 1.2.3(@rspack/core@1.7.5(@swc/helpers@0.5.18))(webpack@5.105.0)
       '@rsdoctor/utils': 1.2.3(@rspack/core@1.7.5(@swc/helpers@0.5.18))(webpack@5.105.0)
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       browserslist-load-config: 1.0.1
       enhanced-resolve: 5.12.0
       filesize: 10.1.6
@@ -6801,6 +6879,8 @@ snapshots:
       dom-accessibility-api: 0.6.3
       picocolors: 1.1.1
       redent: 3.0.0
+
+  '@toon-format/toon@0.9.0': {}
 
   '@tsconfig/node10@1.0.12': {}
 
@@ -7260,9 +7340,14 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios@1.13.5:
+  axios-retry@4.5.0(axios@1.13.5(debug@4.4.3)):
     dependencies:
-      follow-redirects: 1.15.11
+      axios: 1.13.5(debug@4.4.3)
+      is-retry-allowed: 2.2.0
+
+  axios@1.13.5(debug@4.4.3):
+    dependencies:
+      follow-redirects: 1.15.11(debug@4.4.3)
       form-data: 4.0.5
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -7397,6 +7482,10 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
+
   bytes@3.1.2: {}
 
   cac@6.7.14: {}
@@ -7485,6 +7574,8 @@ snapshots:
 
   ci-info@3.9.0: {}
 
+  ci-info@4.4.0: {}
+
   cjs-module-lexer@1.4.3: {}
 
   cliui@8.0.1:
@@ -7563,21 +7654,6 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-config: 29.7.0(@types/node@22.19.9)(ts-node@10.9.2(@types/node@22.19.9)(typescript@5.8.3))
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  create-jest@29.7.0(@types/node@25.2.3)(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.8.3)):
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@25.2.3)(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.8.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -7756,6 +7832,13 @@ snapshots:
 
   deepmerge@4.3.1: {}
 
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.5.0:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
   define-data-property@1.1.4:
     dependencies:
       es-define-property: 1.0.1
@@ -7763,6 +7846,8 @@ snapshots:
       gopd: 1.2.0
 
   define-lazy-prop@2.0.0: {}
+
+  define-lazy-prop@3.0.0: {}
 
   define-properties@1.2.1:
     dependencies:
@@ -8060,6 +8145,12 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.0.6: {}
+
+  eventsource@4.1.0:
+    dependencies:
+      eventsource-parser: 3.0.6
+
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -8141,7 +8232,9 @@ snapshots:
 
   flexsearch@0.8.212: {}
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.15.11(debug@4.4.3):
+    optionalDependencies:
+      debug: 4.4.3
 
   for-each@0.3.5:
     dependencies:
@@ -8222,6 +8315,15 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
+
+  git-up@7.0.0:
+    dependencies:
+      is-ssh: 1.4.1
+      parse-url: 8.1.0
+
+  git-url-parse@15.0.0:
+    dependencies:
+      git-up: 7.0.0
 
   github-slugger@2.0.0: {}
 
@@ -8540,6 +8642,10 @@ snapshots:
 
   is-callable@1.2.7: {}
 
+  is-ci@4.1.0:
+    dependencies:
+      ci-info: 4.4.0
+
   is-core-module@2.16.1:
     dependencies:
       hasown: 2.0.2
@@ -8558,6 +8664,8 @@ snapshots:
   is-decimal@2.0.1: {}
 
   is-docker@2.2.1: {}
+
+  is-docker@3.0.0: {}
 
   is-extendable@0.1.1: {}
 
@@ -8585,6 +8693,10 @@ snapshots:
 
   is-hexadecimal@2.0.1: {}
 
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
+
   is-map@2.0.3: {}
 
   is-negative-zero@2.0.3: {}
@@ -8607,11 +8719,17 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
+  is-retry-allowed@2.2.0: {}
+
   is-set@2.0.3: {}
 
   is-shared-array-buffer@1.0.4:
     dependencies:
       call-bound: 1.0.4
+
+  is-ssh@1.4.1:
+    dependencies:
+      protocols: 2.0.2
 
   is-stream@2.0.1: {}
 
@@ -8644,6 +8762,10 @@ snapshots:
   is-wsl@2.2.0:
     dependencies:
       is-docker: 2.2.1
+
+  is-wsl@3.1.1:
+    dependencies:
+      is-inside-container: 1.0.0
 
   isarray@2.0.5: {}
 
@@ -8755,25 +8877,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@25.2.3)(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.8.3)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.8.3))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@25.2.3)(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.8.3))
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@25.2.3)(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.8.3))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest-config@29.7.0(@types/node@22.19.9)(ts-node@10.9.2(@types/node@22.19.9)(typescript@5.8.3)):
     dependencies:
       '@babel/core': 7.29.0
@@ -8801,68 +8904,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.9
       ts-node: 10.9.2(@types/node@22.19.9)(typescript@5.8.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@22.19.9)(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.8.3)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 22.19.9
-      ts-node: 10.9.2(@types/node@25.2.3)(typescript@5.8.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@25.2.3)(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.8.3)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 25.2.3
-      ts-node: 10.9.2(@types/node@25.2.3)(typescript@5.8.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -9100,19 +9141,9 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@25.2.3)(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.8.3)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.8.3))
-      '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@25.2.3)(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.8.3))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jiti@2.6.1: {}
+
+  jose@5.10.0: {}
 
   js-tokens@10.0.0: {}
 
@@ -9778,6 +9809,10 @@ snapshots:
 
   node-int64@0.4.0: {}
 
+  node-persist@4.0.4:
+    dependencies:
+      p-limit: 3.1.0
+
   node-releases@2.0.27: {}
 
   normalize-path@3.0.0: {}
@@ -9847,6 +9882,13 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
+  open@10.2.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      wsl-utils: 0.1.0
+
   open@8.4.2:
     dependencies:
       define-lazy-prop: 2.0.0
@@ -9891,6 +9933,14 @@ snapshots:
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
+
+  parse-path@7.1.0:
+    dependencies:
+      protocols: 2.0.2
+
+  parse-url@8.1.0:
+    dependencies:
+      parse-path: 7.1.0
 
   parse5@7.3.0:
     dependencies:
@@ -10118,7 +10168,15 @@ snapshots:
       kleur: 3.0.3
       sisteransi: 1.0.5
 
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
+
   property-information@7.1.0: {}
+
+  protocols@2.0.2: {}
 
   proxy-from-env@1.1.0: {}
 
@@ -10341,6 +10399,8 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  retry@0.12.0: {}
+
   reusify@1.1.0: {}
 
   rollup@4.57.1:
@@ -10377,6 +10437,8 @@ snapshots:
   rrweb-cssom@0.8.0: {}
 
   rslog@1.3.2: {}
+
+  run-applescript@7.1.0: {}
 
   run-parallel@1.2.0:
     dependencies:
@@ -10949,32 +11011,12 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.19.9)(ts-node@10.9.2(@types/node@22.19.9)(typescript@5.8.3)))(typescript@5.8.3):
+  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0)(typescript@5.8.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.8
       jest: 29.7.0(@types/node@22.19.9)(ts-node@10.9.2(@types/node@22.19.9)(typescript@5.8.3))
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.7.4
-      type-fest: 4.41.0
-      typescript: 5.8.3
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.29.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.0)
-      jest-util: 29.7.0
-
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@25.2.3)(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.8.3)))(typescript@5.8.3):
-    dependencies:
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      handlebars: 4.7.8
-      jest: 29.7.0(@types/node@25.2.3)(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.8.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -11006,25 +11048,6 @@ snapshots:
       typescript: 5.8.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-
-  ts-node@10.9.2(@types/node@25.2.3)(typescript@5.8.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 25.2.3
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.4
-      make-error: 1.3.6
-      typescript: 5.8.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optional: true
 
   ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3):
     dependencies:
@@ -11488,6 +11511,10 @@ snapshots:
 
   ws@8.19.0: {}
 
+  wsl-utils@0.1.0:
+    dependencies:
+      is-wsl: 3.1.1
+
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
@@ -11513,5 +11540,28 @@ snapshots:
   yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zephyr-agent@1.0.0(https-proxy-agent@7.0.6):
+    dependencies:
+      '@toon-format/toon': 0.9.0
+      axios: 1.13.5(debug@4.4.3)
+      axios-retry: 4.5.0(axios@1.13.5(debug@4.4.3))
+      debug: 4.4.3
+      eventsource: 4.1.0
+      git-url-parse: 15.0.0
+      https-proxy-agent: 7.0.6
+      is-ci: 4.1.0
+      jose: 5.10.0
+      node-persist: 4.0.4
+      open: 10.2.0
+      proper-lockfile: 4.1.2
+      tslib: 2.8.1
+      zephyr-edge-contract: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  zephyr-edge-contract@1.0.0:
+    dependencies:
+      tslib: 2.8.1
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary
Add Zephyr OTA support across Sparkling scaffolding, CLI deploy flow, and native SDK runtime handling.

## Related issues
Standalone.

## Changes
- scaffold Zephyr-ready apps from `create-sparkling-app` with docs/tests
- add `sparkling-app-cli deploy:zephyr` and runtime config generation
- add Android/iOS Zephyr OTA managers and container/view-controller update handling
- document the Zephyr OTA flow

## How to test
`pnpm --filter create-sparkling-app test`
`pnpm --filter create-sparkling-app build`
`pnpm --filter sparkling-app-cli test`
`pnpm --filter sparkling-app-cli build`

Native manual/runtime verification still needed for Android/iOS OTA flows.

## Checklist
- [ ] I read `CONTRIBUTING.md`.
- [ ] I linked a related issue (or explained why this is standalone).
- [x] I ran relevant checks
- [x] I updated docs/examples (if needed).
- [x] I added/updated tests (if applicable), or explained why not.
