### PR TITLE
feat(cli): auto-start dev server when running on mobile

### DIFF
--- a/docs/en/guide/cli.md
+++ b/docs/en/guide/cli.md
@@ -41,9 +41,18 @@ npx sparkling dev
 | Option | Description |
 | --- | --- |
 | `--config <path>` | Path to `app.config.ts` (default: `app.config.ts`) |
-| `--port <number>` | Dev server port (default: `5969`) |
+| `--port <number>` | Dev server port (default: `app.config.ts -> dev.server.port`, fallback `5969`) |
 
 The default port **5969** spells **LYNX** on a phone keypad (L=5, Y=9, N=6, X=9).
+
+Port resolution priority is:
+
+1. `--port`
+2. `app.config.ts` `dev.server.port`
+3. `app.config.ts` `lynxConfig.server.port`
+4. `5969`
+
+If you run `sparkling dev --port <number>`, the CLI writes it back to `app.config.ts` as `dev.server.port`.
 
 Once the server is running, point your app to `http://<your-ip>:5969/main.lynx.bundle` (or whatever entry point you need). In the project template, **DEBUG** builds connect to the dev server automatically.
 
@@ -94,10 +103,14 @@ npx sparkling run:android
 This command will:
 
 1. Autolink method modules for Android
-2. Build the Lynx bundle
-3. Run `gradlew assembleDebug`
-4. Install the APK on a connected device/emulator
-5. Launch the main activity
+2. Resolve the dev port from `app.config.ts` and auto-start a dev server if needed
+3. Auto-detect device type and inject host for template debug URL:
+   - emulator: `127.0.0.1` (and auto `adb reverse`)
+   - physical device: host LAN IPv4
+4. Build the Lynx bundle
+5. Run `gradlew assembleDebug`
+6. Install the APK on a connected device/emulator
+7. Launch the main activity
 
 ### `sparkling run:ios`
 
@@ -117,10 +130,11 @@ npx sparkling run:ios
 This command will:
 
 1. Pick a simulator (prefers a booted device; falls back to common names like iPhone 17 Pro)
-2. Autolink method modules for iOS
-3. Run `pod install` (unless `--skip-pod-install`)
-4. Build the Lynx bundle
-5. Build, install, and launch the app on the simulator
+2. Resolve the dev port from `app.config.ts` and auto-start a dev server if needed
+3. Autolink method modules for iOS
+4. Run `pod install` (unless `--skip-pod-install`)
+5. Build the Lynx bundle
+6. Build, install, and launch the app on the simulator
 
 You can also set the `SPARKLING_IOS_SIMULATOR` environment variable to specify a default simulator.
 

--- a/docs/zh/guide/cli.md
+++ b/docs/zh/guide/cli.md
@@ -41,9 +41,18 @@ npx sparkling dev
 | 选项 | 说明 |
 | --- | --- |
 | `--config <path>` | `app.config.ts` 路径（默认：`app.config.ts`） |
-| `--port <number>` | 开发服务器端口（默认：`5969`） |
+| `--port <number>` | 开发服务器端口（默认：`app.config.ts -> dev.server.port`，兜底 `5969`） |
 
 默认端口 **5969** 对应手机九宫格键盘上的 **LYNX**（L=5, Y=9, N=6, X=9）。
+
+端口优先级为：
+
+1. `--port`
+2. `app.config.ts` 的 `dev.server.port`
+3. `app.config.ts` 的 `lynxConfig.server.port`
+4. `5969`
+
+当执行 `sparkling dev --port <number>` 时，CLI 会把端口回写到 `app.config.ts` 的 `dev.server.port`。
 
 服务器启动后，将应用指向 `http://<你的IP>:5969/main.lynx.bundle`（或你需要的入口）。项目模板中，**DEBUG** 构建会自动连接开发服务器。
 
@@ -94,10 +103,14 @@ npx sparkling run:android
 该命令会依次执行：
 
 1. 为 Android 自动链接方法模块
-2. 构建 Lynx bundle
-3. 运行 `gradlew assembleDebug`
-4. 将 APK 安装到已连接的设备/模拟器
-5. 启动主 Activity
+2. 从 `app.config.ts` 解析端口，并在需要时自动拉起 dev server
+3. 自动识别目标设备并注入模板调试地址 host：
+   - 模拟器：`127.0.0.1`（并自动执行 `adb reverse`）
+   - 真机：本机局域网 IPv4
+4. 构建 Lynx bundle
+5. 运行 `gradlew assembleDebug`
+6. 将 APK 安装到已连接的设备/模拟器
+7. 启动主 Activity
 
 ### `sparkling run:ios`
 
@@ -117,10 +130,11 @@ npx sparkling run:ios
 该命令会依次执行：
 
 1. 选择模拟器（优先选择已启动的设备，否则回退到 iPhone 17 Pro 等常用型号）
-2. 为 iOS 自动链接方法模块
-3. 运行 `pod install`（除非指定 `--skip-pod-install`）
-4. 构建 Lynx bundle
-5. 构建、安装并在模拟器上启动应用
+2. 从 `app.config.ts` 解析端口，并在需要时自动拉起 dev server
+3. 为 iOS 自动链接方法模块
+4. 运行 `pod install`（除非指定 `--skip-pod-install`）
+5. 构建 Lynx bundle
+6. 构建、安装并在模拟器上启动应用
 
 你也可以通过设置 `SPARKLING_IOS_SIMULATOR` 环境变量来指定默认模拟器。
 

--- a/packages/create-sparkling-app/src/create-app/template-manager.ts
+++ b/packages/create-sparkling-app/src/create-app/template-manager.ts
@@ -3,7 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 import fs from 'node:fs';
 import path from 'node:path';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 
 import { DEFAULT_TEMPLATE_PACKAGE } from './constants';
 import { ui } from '../ui';
@@ -15,6 +15,14 @@ export const sanitizeCacheKey = (packageName: string, version: string) => {
 };
 
 const NPM_TEMPLATE_PREFIX = 'npm:';
+
+const SAFE_GIT_REF = /^[a-zA-Z0-9._\-/]+$/;
+
+function validateGitRef(value: string, label: string): void {
+  if (!SAFE_GIT_REF.test(value)) {
+    throw new Error(`Invalid characters in GitHub ${label}: ${value}`);
+  }
+}
 
 export async function resolveCustomTemplate(templateInput: string, version?: string): Promise<string> {
   const trimmedInput = templateInput.trim();
@@ -37,13 +45,16 @@ export async function resolveCustomTemplate(templateInput: string, version?: str
 
   if (githubMatch) {
     const [, owner, repo, branch = 'main', subPath = ''] = githubMatch;
+    validateGitRef(owner, 'owner');
+    validateGitRef(repo, 'repo');
+    validateGitRef(branch, 'branch');
     const templateDir = path.join(process.cwd(), '.temp-templates', `${owner}-${repo}-${branch}`);
 
     try {
       if (fs.existsSync(templateDir)) {
-        execSync(`git -C "${templateDir}" pull`, { stdio: 'pipe' });
+        execFileSync('git', ['-C', templateDir, 'pull'], { stdio: 'pipe' });
       } else {
-        execSync(`git clone --depth 1 --branch ${branch} https://github.com/${owner}/${repo}.git "${templateDir}"`, { stdio: 'pipe' });
+        execFileSync('git', ['clone', '--depth', '1', '--branch', branch, `https://github.com/${owner}/${repo}.git`, templateDir], { stdio: 'pipe' });
       }
 
       const fullPath = subPath ? path.join(templateDir, subPath) : templateDir;
@@ -175,7 +186,7 @@ export async function resolveNpmTemplate(
     // precise error output below if installation fails.
     if (!skipInstall) {
       try {
-        execSync(`npm install ${normalizedName}@${versionSpecifier} --no-save --package-lock=false --no-audit --no-fund --silent`,
+        execFileSync('npm', ['install', `${normalizedName}@${versionSpecifier}`, '--no-save', '--package-lock=false', '--no-audit', '--no-fund', '--silent'],
           {
             cwd: installRoot,
             stdio: 'pipe',

--- a/packages/playground/android/app/src/main/AndroidManifest.xml
+++ b/packages/playground/android/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
 
     <application
         android:name="com.tiktok.sparkling.playground.SparklingApplication"
+        android:allowBackup="false"
         android:icon="@drawable/sparkling_icon"
         android:label="@string/app_name"
         android:roundIcon="@drawable/sparkling_icon"

--- a/packages/playground/android/app/src/main/res/xml/network_security_config.xml
+++ b/packages/playground/android/app/src/main/res/xml/network_security_config.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <!-- The playground app allows all cleartext traffic for dev server testing. -->
-    <base-config cleartextTrafficPermitted="true" />
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">localhost</domain>
+        <domain includeSubdomains="false">127.0.0.1</domain>
+        <domain includeSubdomains="false">10.0.2.2</domain>
+    </domain-config>
 </network-security-config>

--- a/packages/playground/ios/Info.plist
+++ b/packages/playground/ios/Info.plist
@@ -6,8 +6,6 @@
 	<dict>
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
 	</dict>
 </dict>
 </plist>

--- a/packages/sparkling-app-cli/README.md
+++ b/packages/sparkling-app-cli/README.md
@@ -38,6 +38,24 @@ sparkling run:ios
 
 Run `sparkling --help` to see all available commands and options.
 
+## Dev Server Port And Host Behavior
+
+- `sparkling dev` resolves the port from (highest to lowest): `--port` -> `app.config.ts` `dev.server.port` -> `app.config.ts` `lynxConfig.server.port` -> `5969`.
+- `sparkling dev --port <x>` persists the selected port back to `app.config.ts` as `dev.server.port`.
+- `sparkling run:ios` and `sparkling run:android` reuse the same resolved port and auto-start a dev server when needed.
+- For Android, `run:android` auto-detects connected targets:
+  - emulator: app uses `127.0.0.1` and CLI applies `adb reverse tcp:<port> tcp:<port>`
+  - physical device: app uses your local LAN IPv4 and CLI starts the server on `0.0.0.0`
+
+## Template Debug/Release Loading
+
+In the app template:
+
+- **Debug** builds can load either:
+  - remote URL source (for example `http://<host>:<port>/main.lynx.bundle`), or
+  - local asset bundle source (for example `main.lynx.bundle`).
+- **Release** builds do not rely on debug-tool and load from assets only (`bundle=...`).
+
 ## Local testing
 
 When developing inside the Sparkling monorepo, see [LOCAL_TESTING.md](./LOCAL_TESTING.md) for building this CLI, running `sparkling` / `sparkling-app-cli` from the workspace, and trying commands from an app directory.

--- a/packages/sparkling-app-cli/src/__tests__/config-dev-port.test.ts
+++ b/packages/sparkling-app-cli/src/__tests__/config-dev-port.test.ts
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 TikTok Pte. Ltd.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+// @ts-nocheck
+/// <reference types="jest" />
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { getConfiguredDevServerPorts, resolveDevServerPort, updateDevServerPortInAppConfig } from '../config';
+
+describe('dev server port config helpers', () => {
+  it('uses default port when app config has no port', () => {
+    const port = resolveDevServerPort({ lynxConfig: {} } as never);
+    expect(port).toBe(5969);
+  });
+
+  it('uses configured dev.server.port when present', () => {
+    const port = resolveDevServerPort({ lynxConfig: {}, dev: { server: { port: 7001 } } } as never);
+    expect(port).toBe(7001);
+  });
+
+  it('falls back to lynxConfig.server.port when dev.server.port is missing', () => {
+    const port = resolveDevServerPort({ lynxConfig: { server: { port: 7003 } } } as never);
+    expect(port).toBe(7003);
+  });
+
+  it('prefers dev.server.port over lynxConfig.server.port when both exist', () => {
+    const port = resolveDevServerPort({ lynxConfig: { server: { port: 7003 } }, dev: { server: { port: 7004 } } } as never);
+    expect(port).toBe(7004);
+  });
+
+  it('extracts both configured ports for conflict checks', () => {
+    const ports = getConfiguredDevServerPorts({ lynxConfig: { server: { port: 7010 } }, dev: { server: { port: 7020 } } } as never);
+    expect(ports).toEqual({ devPort: 7020, lynxPort: 7010 });
+  });
+
+  it('updates existing dev.server.port in app.config.ts', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'spk-port-'));
+    const file = path.join(dir, 'app.config.ts');
+    fs.writeFileSync(file, 'const config = {\n  lynxConfig: {},\n  dev: {\n    server: {\n      port: 5969,\n    },\n  },\n}\n');
+
+    const updated = updateDevServerPortInAppConfig(file, 7001);
+    const content = fs.readFileSync(file, 'utf8');
+
+    expect(updated).toBe(true);
+    expect(content).toContain('port: 7001');
+  });
+
+  it('inserts dev.server.port when missing in app.config.ts', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'spk-port-'));
+    const file = path.join(dir, 'app.config.ts');
+    fs.writeFileSync(file, 'const config = {\n  lynxConfig: {},\n  appName: "demo",\n}\n');
+
+    const updated = updateDevServerPortInAppConfig(file, 7002);
+    const content = fs.readFileSync(file, 'utf8');
+
+    expect(updated).toBe(true);
+    expect(content).toContain('dev: {');
+    expect(content).toContain('server: {');
+    expect(content).toContain('port: 7002');
+  });
+});

--- a/packages/sparkling-app-cli/src/__tests__/dev-server.test.ts
+++ b/packages/sparkling-app-cli/src/__tests__/dev-server.test.ts
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 TikTok Pte. Ltd.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+// @ts-nocheck
+/// <reference types="jest" />
+import { ensureDevServerRunning } from '../utils/dev-server';
+
+const spawnMock = jest.fn();
+
+jest.mock('node:child_process', () => ({
+  spawn: (...args: unknown[]) => spawnMock(...args),
+}));
+
+describe('ensureDevServerRunning', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    spawnMock.mockReset();
+    spawnMock.mockReturnValue({ unref: jest.fn() });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('does not start a new process when dev server is already running', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true }) as unknown as typeof fetch;
+
+    await ensureDevServerRunning('/tmp/project', 5969);
+
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('treats non-2xx HTTP responses as running server', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 404 }) as unknown as typeof fetch;
+
+    await ensureDevServerRunning('/tmp/project', 5969);
+
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('starts sparkling-app-cli dev when server is not running', async () => {
+    global.fetch = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('connect ECONNREFUSED'))
+      .mockRejectedValueOnce(new Error('connect ECONNREFUSED'))
+      .mockResolvedValueOnce({ ok: true }) as unknown as typeof fetch;
+
+    const argvBackup = process.argv.slice();
+    process.argv[1] = '/tmp/mock-cli-entry.js';
+
+    await ensureDevServerRunning('/tmp/project', 5969);
+
+    const expectedCommand = process.platform === 'darwin' ? 'script' : process.execPath;
+    const expectedArgs = process.platform === 'darwin'
+      ? ['-q', '/dev/null', process.execPath, '/tmp/mock-cli-entry.js', 'dev', '--port', '5969', '--host', '127.0.0.1']
+      : ['/tmp/mock-cli-entry.js', 'dev', '--port', '5969', '--host', '127.0.0.1'];
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(spawnMock).toHaveBeenCalledWith(
+      expectedCommand,
+      expectedArgs,
+      expect.objectContaining({
+        cwd: '/tmp/project',
+        detached: true,
+        stdio: 'ignore',
+      }),
+    );
+
+    process.argv = argvBackup;
+  });
+});

--- a/packages/sparkling-app-cli/src/commands/dev.ts
+++ b/packages/sparkling-app-cli/src/commands/dev.ts
@@ -2,8 +2,13 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 import path from 'node:path';
-import { createDevLynxConfig } from '../config';
-import { DEV_SERVER_PORT } from '../constants';
+import {
+  createDevLynxConfig,
+  getConfiguredDevServerPorts,
+  loadAppConfig,
+  resolveDevServerPort,
+  updateDevServerPortInAppConfig,
+} from '../config';
 import { runCommand } from '../utils/exec';
 import { ui } from '../utils/ui';
 import { isVerboseEnabled, verboseLog } from '../utils/verbose';
@@ -12,17 +17,38 @@ export interface DevOptions {
   cwd: string;
   configFile?: string;
   port?: number;
+  host?: string;
 }
 
 export async function devProject(options: DevOptions): Promise<void> {
-  const configPath = path.resolve(options.cwd, options.configFile ?? 'app.config.ts');
-  const port = options.port ?? DEV_SERVER_PORT;
-  const tempConfigPath = createDevLynxConfig(options.cwd, configPath, port);
+  const { config, configPath } = await loadAppConfig(options.cwd, options.configFile ?? 'app.config.ts');
+  const { devPort, lynxPort } = getConfiguredDevServerPorts(config);
+  if (devPort !== undefined && lynxPort !== undefined && devPort !== lynxPort) {
+    console.warn(ui.warn(
+      `Port config mismatch detected: dev.server.port=${devPort} and lynxConfig.server.port=${lynxPort}. ` +
+      `sparkling-app-cli uses dev.server.port (${devPort}).`,
+    ));
+  }
+
+  const configuredPort = resolveDevServerPort(config);
+  const port = options.port ?? configuredPort;
+
+  if (options.port !== undefined && options.port !== configuredPort) {
+    const updated = updateDevServerPortInAppConfig(configPath, options.port);
+    if (updated) {
+      console.log(ui.info(`Updated app.config.ts dev.server.port to ${options.port}.`));
+    }
+  }
+
+  const tempConfigPath = createDevLynxConfig(options.cwd, configPath, port, options.host);
 
   if (isVerboseEnabled()) {
     verboseLog(`App config path: ${configPath}`);
     verboseLog(`Temp Lynx config: ${tempConfigPath}`);
     verboseLog(`Dev server port: ${port}`);
+    if (options.host) {
+      verboseLog(`Dev server host: ${options.host}`);
+    }
   }
 
   console.log(ui.headline(`Starting Rspeedy dev server on port ${port} with config from ${path.relative(options.cwd, configPath)}`));

--- a/packages/sparkling-app-cli/src/commands/run-android.ts
+++ b/packages/sparkling-app-cli/src/commands/run-android.ts
@@ -3,15 +3,66 @@
 // LICENSE file in the root directory of this source tree.
 import fs from 'node:fs';
 import path from 'node:path';
+import os from 'node:os';
+import { execSync } from 'node:child_process';
+import { getConfiguredDevServerPorts, loadAppConfig, resolveDevServerPort } from '../config';
 import { autolink } from './autolink';
 import { buildProject } from './build';
 import { runCommand } from '../utils/exec';
 import { ui } from '../utils/ui';
 import { isVerboseEnabled, verboseLog } from '../utils/verbose';
+import { ensureDevServerRunning } from '../utils/dev-server';
 
 export interface RunAndroidOptions {
   cwd: string;
   skipCopy?: boolean;
+}
+
+interface AndroidDevice {
+  serial: string;
+  isEmulator: boolean;
+}
+
+function listConnectedAndroidDevices(): AndroidDevice[] {
+  try {
+    const output = execSync('adb devices', { encoding: 'utf8' });
+    const lines = output.split(/\r?\n/).slice(1);
+    const devices: AndroidDevice[] = [];
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      const [serial, state] = trimmed.split(/\s+/);
+      if (state !== 'device') continue;
+      devices.push({ serial, isEmulator: serial.startsWith('emulator-') });
+    }
+    return devices;
+  } catch {
+    return [];
+  }
+}
+
+function resolveLocalIPv4(): string {
+  const interfaces = os.networkInterfaces();
+  const preferredOrder = ['en0', 'en1', 'wlan0'];
+
+  for (const name of preferredOrder) {
+    const candidates = interfaces[name] ?? [];
+    for (const addr of candidates) {
+      if (addr.family === 'IPv4' && !addr.internal) {
+        return addr.address;
+      }
+    }
+  }
+
+  for (const candidates of Object.values(interfaces)) {
+    for (const addr of candidates ?? []) {
+      if (addr.family === 'IPv4' && !addr.internal) {
+        return addr.address;
+      }
+    }
+  }
+
+  return '127.0.0.1';
 }
 
 function resolveAndroidAppGradle(cwd: string): string | null {
@@ -61,6 +112,34 @@ function resolveAndroidLaunchActivity(cwd: string, pkg: string): string {
 }
 
 export async function runAndroid(options: RunAndroidOptions): Promise<void> {
+  const { config } = await loadAppConfig(options.cwd);
+  const { devPort: configuredDevPort, lynxPort } = getConfiguredDevServerPorts(config);
+  if (configuredDevPort !== undefined && lynxPort !== undefined && configuredDevPort !== lynxPort) {
+    console.warn(ui.warn(
+      `Port config mismatch detected: dev.server.port=${configuredDevPort} and lynxConfig.server.port=${lynxPort}. ` +
+      `run:android uses dev.server.port (${configuredDevPort}).`,
+    ));
+  }
+  const devPort = resolveDevServerPort(config);
+  const connectedDevices = listConnectedAndroidDevices();
+  const emulatorSerials = connectedDevices.filter(d => d.isEmulator).map(d => d.serial);
+  const devServerHostForApp = emulatorSerials.length > 0 ? '127.0.0.1' : resolveLocalIPv4();
+  const devServerHostForCli = emulatorSerials.length > 0 ? '127.0.0.1' : '0.0.0.0';
+
+  await ensureDevServerRunning(options.cwd, devPort, devServerHostForCli);
+
+  for (const serial of emulatorSerials) {
+    await runCommand('adb', ['-s', serial, 'reverse', `tcp:${devPort}`, `tcp:${devPort}`], {
+      cwd: options.cwd,
+      ignoreFailure: true,
+    });
+  }
+
+  if (isVerboseEnabled()) {
+    verboseLog(
+      `run:android options -> skipCopy: ${options.skipCopy === true}, devPort: ${devPort}, devHost: ${devServerHostForApp}, emulatorCount: ${emulatorSerials.length}`,
+    );
+  }
   await autolink({ cwd: options.cwd, platform: 'android' });
   await buildProject({ cwd: options.cwd, skipCopy: options.skipCopy });
 
@@ -73,10 +152,15 @@ export async function runAndroid(options: RunAndroidOptions): Promise<void> {
     verboseLog(`Env overrides: ${JSON.stringify(env)}`);
   }
   // Always build first so artifacts exist even when no device is connected
-  await runCommand(gradleCmd, ['assembleDebug'], { cwd: androidDir, env });
+  const gradleArgs = [
+    `-PsparklingDevServerHost=${devServerHostForApp}`,
+    `-PsparklingDevServerPort=${devPort}`,
+  ];
+
+  await runCommand(gradleCmd, ['assembleDebug', ...gradleArgs], { cwd: androidDir, env });
   // Try to install if a device is connected; ignore failure so CI/headless environments are not blocked
   console.log(ui.tip('Attempting device install (if any devices are connected)...'));
-  await runCommand(gradleCmd, ['installDebug'], { cwd: androidDir, ignoreFailure: true, env });
+  await runCommand(gradleCmd, ['installDebug', ...gradleArgs], { cwd: androidDir, ignoreFailure: true, env });
   // Attempt to launch the app on a connected device
   const pkg = resolveAndroidPackageId(options.cwd);
   const activity = resolveAndroidLaunchActivity(options.cwd, pkg);

--- a/packages/sparkling-app-cli/src/commands/run-ios.ts
+++ b/packages/sparkling-app-cli/src/commands/run-ios.ts
@@ -4,11 +4,13 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
+import { getConfiguredDevServerPorts, loadAppConfig, resolveDevServerPort } from '../config';
 import { autolink } from './autolink';
 import { buildProject } from './build';
 import { runCommand } from '../utils/exec';
 import { ui } from '../utils/ui';
 import { isVerboseEnabled, verboseLog } from '../utils/verbose';
+import { ensureDevServerRunning } from '../utils/dev-server';
 
 export interface RunIosOptions {
   cwd: string;
@@ -112,10 +114,6 @@ async function ensureRequiredBundler(gemfileDir: string): Promise<void> {
 
   console.log(ui.info(`Installing required Bundler version ${requiredVersion}...`));
 
-  // #region agent log
-  fetch('http://127.0.0.1:7242/ingest/6802e160-a55d-4751-84f7-c7cc9d523b20',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'run-ios.ts:ensureRequiredBundler',message:'Ruby env info before gem install',data:{whichRuby:(() => { try { return execSync('which ruby', {stdio:'pipe'}).toString().trim(); } catch { return 'unknown'; } })(),whichGem:(() => { try { return execSync('which gem', {stdio:'pipe'}).toString().trim(); } catch { return 'unknown'; } })(),gemEnv:(() => { try { return execSync('gem environment home', {stdio:'pipe'}).toString().trim(); } catch { return 'unknown'; } })(),rubyVersion:(() => { try { return execSync('ruby --version', {stdio:'pipe'}).toString().trim(); } catch { return 'unknown'; } })(),requiredVersion},timestamp:Date.now(),runId:'run1',hypothesisId:'H1'})}).catch(()=>{});
-  // #endregion
-
   // First try with --user-install to avoid permission issues with system Ruby
   try {
     await runCommand('gem', ['install', '--user-install', `bundler:${requiredVersion}`], { cwd: gemfileDir });
@@ -135,18 +133,11 @@ async function ensureRequiredBundler(gemfileDir: string): Promise<void> {
 
   // After install, the user gem bin may not be in PATH. Ensure bundle can find it.
   if (!isBundlerVersionInstalled(requiredVersion)) {
-    // #region agent log
-    fetch('http://127.0.0.1:7242/ingest/6802e160-a55d-4751-84f7-c7cc9d523b20',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'run-ios.ts:ensureRequiredBundler:postInstall',message:'Bundler still not found after install attempt',data:{gemList:(() => { try { return execSync('gem list bundler --exact --versions', {stdio:'pipe'}).toString().trim(); } catch { return 'unknown'; } })(),userGemDir:(() => { try { return execSync('ruby -e "puts Gem.user_dir"', {stdio:'pipe'}).toString().trim(); } catch { return 'unknown'; } })()},timestamp:Date.now(),runId:'run1',hypothesisId:'H2'})}).catch(()=>{});
-    // #endregion
     console.warn(
       ui.warn(
         `Bundler ${requiredVersion} could not be verified after install. Proceeding anyway...`,
       ),
     );
-  } else {
-    // #region agent log
-    fetch('http://127.0.0.1:7242/ingest/6802e160-a55d-4751-84f7-c7cc9d523b20',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'run-ios.ts:ensureRequiredBundler:success',message:'Bundler installed successfully',data:{requiredVersion,gemList:(() => { try { return execSync('gem list bundler --exact --versions', {stdio:'pipe'}).toString().trim(); } catch { return 'unknown'; } })()},timestamp:Date.now(),runId:'run1',hypothesisId:'H1'})}).catch(()=>{});
-    // #endregion
   }
 }
 
@@ -263,8 +254,18 @@ function pickSimulator(preferred?: string): SimulatorDevice | null {
 }
 
 export async function runIos(options: RunIosOptions): Promise<void> {
+  const { config } = await loadAppConfig(options.cwd);
+  const { devPort: configuredDevPort, lynxPort } = getConfiguredDevServerPorts(config);
+  if (configuredDevPort !== undefined && lynxPort !== undefined && configuredDevPort !== lynxPort) {
+    console.warn(ui.warn(
+      `Port config mismatch detected: dev.server.port=${configuredDevPort} and lynxConfig.server.port=${lynxPort}. ` +
+      `run:ios uses dev.server.port (${configuredDevPort}).`,
+    ));
+  }
+  const devPort = resolveDevServerPort(config);
+  await ensureDevServerRunning(options.cwd, devPort);
   if (isVerboseEnabled()) {
-    verboseLog(`run:ios options -> skipCopy: ${options.skipCopy === true}, device: ${options.device ?? '(auto)'}, skipPodInstall: ${options.skipPodInstall === true}`);
+    verboseLog(`run:ios options -> skipCopy: ${options.skipCopy === true}, device: ${options.device ?? '(auto)'}, skipPodInstall: ${options.skipPodInstall === true}, devPort: ${devPort}`);
   }
   const preferredDevice = options.device ?? process.env.SPARKLING_IOS_SIMULATOR;
   const device = pickSimulator(preferredDevice);
@@ -416,6 +417,13 @@ export async function runIos(options: RunIosOptions): Promise<void> {
     console.log(ui.info('Installing app on simulator...'));
     await runCommand('xcrun', ['simctl', 'install', device.udid, appPath], { cwd: options.cwd, ignoreFailure: true });
     console.log(ui.info(`Launching ${bundleId}...`));
-    await runCommand('xcrun', ['simctl', 'launch', device.udid, bundleId], { cwd: options.cwd, ignoreFailure: true });
+    await runCommand('xcrun', ['simctl', 'launch', device.udid, bundleId], {
+      cwd: options.cwd,
+      ignoreFailure: true,
+      env: {
+        SIMCTL_CHILD_SPARKLING_DEV_SERVER_PORT: String(devPort),
+        SIMCTL_CHILD_SPARKLING_DEV_SERVER_HOST: '127.0.0.1',
+      },
+    });
   }
 }

--- a/packages/sparkling-app-cli/src/config.ts
+++ b/packages/sparkling-app-cli/src/config.ts
@@ -9,6 +9,7 @@ import { pathToFileURL } from 'url';
 import { createRequire } from 'module';
 // no url import needed when using require()
 import type { AppConfig } from './types';
+import { DEV_SERVER_PORT } from './constants';
 
 let registeredTsNode = false;
 const pkgRequire = createRequire(__filename);
@@ -54,7 +55,7 @@ function ensureTsNodeRegistered() {
 export function createTempLynxConfig(cwd: string, appConfigPath: string): string {
   const tempDir = path.resolve(cwd, '.sparkling');
   fs.mkdirSync(tempDir, { recursive: true });
-  const tempConfigPath = path.join(tempDir, 'lynx.config.ts');
+  const tempConfigPath = path.join(tempDir, 'lynx.build.config.ts');
   const rel = path.relative(tempDir, path.resolve(appConfigPath)).split(path.sep).join('/');
   const content = [
     `import cfgModule from '${rel.startsWith('.') ? rel : './' + rel}'`,
@@ -65,19 +66,101 @@ export function createTempLynxConfig(cwd: string, appConfigPath: string): string
   return tempConfigPath;
 }
 
-export function createDevLynxConfig(cwd: string, appConfigPath: string, port: number): string {
+export function createDevLynxConfig(cwd: string, appConfigPath: string, port: number, host?: string): string {
   const tempDir = path.resolve(cwd, '.sparkling');
   fs.mkdirSync(tempDir, { recursive: true });
-  const tempConfigPath = path.join(tempDir, 'lynx.config.ts');
+  const tempConfigPath = path.join(tempDir, 'lynx.dev.config.ts');
   const rel = path.relative(tempDir, path.resolve(appConfigPath)).split(path.sep).join('/');
   const content = [
     `import cfgModule from '${rel.startsWith('.') ? rel : './' + rel}'`,
     'const cfg: any = (cfgModule as any).default ?? cfgModule',
     'const lynxCfg = cfg.lynxConfig ?? cfg',
-    `export default { ...lynxCfg, server: { ...lynxCfg.server, port: ${port}, strictPort: true } } as any`,
+    `export default { ...lynxCfg, server: { ...lynxCfg.server, port: ${port}, strictPort: true${host ? `, host: ${JSON.stringify(host)}` : ''} } } as any`,
   ].join('\n');
   fs.writeFileSync(tempConfigPath, content);
   return tempConfigPath;
+}
+
+function isValidPort(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0 && value <= 65535;
+}
+
+function toValidPort(value: unknown): number | undefined {
+  if (isValidPort(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10);
+    if (isValidPort(parsed)) {
+      return parsed;
+    }
+  }
+  return undefined;
+}
+
+export function getConfiguredDevServerPorts(config: AppConfig): { devPort?: number; lynxPort?: number } {
+  const devPort = toValidPort((config as { dev?: { server?: { port?: unknown } } }).dev?.server?.port);
+  const lynxCfg = (config as { lynxConfig?: unknown }).lynxConfig as { server?: { port?: unknown } } | undefined;
+  const lynxPort = toValidPort(lynxCfg?.server?.port);
+  return { devPort, lynxPort };
+}
+
+export function resolveDevServerPort(config: AppConfig): number {
+  const { devPort, lynxPort } = getConfiguredDevServerPorts(config);
+  if (devPort !== undefined) {
+    return devPort;
+  }
+  if (lynxPort !== undefined) {
+    return lynxPort;
+  }
+  return DEV_SERVER_PORT;
+}
+
+export function updateDevServerPortInAppConfig(configPath: string, port: number): boolean {
+  if (!isValidPort(port) || !fs.existsSync(configPath)) {
+    return false;
+  }
+
+  const original = fs.readFileSync(configPath, 'utf8');
+
+  if (/\bdev\s*:\s*\{[\s\S]*?\bserver\s*:\s*\{[\s\S]*?\bport\s*:/.test(original)) {
+    const replaced = original.replace(/(\bdev\s*:\s*\{[\s\S]*?\bserver\s*:\s*\{[\s\S]*?\bport\s*:\s*)\d+/, `$1${port}`);
+    if (replaced !== original) {
+      fs.writeFileSync(configPath, replaced);
+      return true;
+    }
+    return false;
+  }
+
+  if (/\bdev\s*:\s*\{[\s\S]*?\bserver\s*:\s*\{/.test(original)) {
+    const replaced = original.replace(/(\bdev\s*:\s*\{[\s\S]*?\bserver\s*:\s*\{)/, `$1\n      port: ${port},`);
+    if (replaced !== original) {
+      fs.writeFileSync(configPath, replaced);
+      return true;
+    }
+  }
+
+  if (/\bdev\s*:\s*\{/.test(original)) {
+    const replaced = original.replace(/(\bdev\s*:\s*\{)/, `$1\n    server: {\n      port: ${port},\n    },`);
+    if (replaced !== original) {
+      fs.writeFileSync(configPath, replaced);
+      return true;
+    }
+  }
+
+  const configDecl = original.match(/const\s+config\s*(?::[^=]+)?=\s*\{/);
+  if (!configDecl || configDecl.index === undefined) {
+    return false;
+  }
+
+  const insertPos = configDecl.index + configDecl[0].length;
+  const after = original.slice(insertPos);
+  const nextLineIndent = after.match(/\n(\s*)\S/);
+  const indent = nextLineIndent?.[1] ?? '  ';
+  const insertion = `\n${indent}dev: {\n${indent}  server: {\n${indent}    port: ${port},\n${indent}  },\n${indent}},`;
+  const updated = `${original.slice(0, insertPos)}${insertion}${original.slice(insertPos)}`;
+  fs.writeFileSync(configPath, updated);
+  return true;
 }
 
 export async function loadAppConfig(cwd: string, configFile = 'app.config.ts'): Promise<{ config: AppConfig; configPath: string }> {
@@ -140,7 +223,7 @@ function loadAppConfigViaEsm(cwd: string, configPath: string, originalError?: un
     `const url = ${JSON.stringify(fileUrl)};`,
     'const mod = await import(url);',
     'const cfg = (mod.default ?? mod);',
-    'const out = { lynxConfig: cfg.lynxConfig ?? {}, platform: cfg.platform ?? {}, paths: cfg.paths ?? {}, appName: cfg.appName, devtool: cfg.devtool };',
+    'const out = { lynxConfig: cfg.lynxConfig ?? {}, platform: cfg.platform ?? {}, paths: cfg.paths ?? {}, appName: cfg.appName, devtool: cfg.devtool, dev: cfg.dev };',
     'process.stdout.write(JSON.stringify(out));',
   ].join('\n');
   fs.writeFileSync(readerScript, script);

--- a/packages/sparkling-app-cli/src/index.ts
+++ b/packages/sparkling-app-cli/src/index.ts
@@ -57,14 +57,19 @@ program
   .command('dev')
   .description('Start Lynx dev server with HMR using app.config.ts')
   .option('--config <path>', 'Path to app.config.ts', 'app.config.ts')
-  .option('--port <number>', `Dev server port (default: ${DEV_SERVER_PORT})`, String(DEV_SERVER_PORT))
+  .option('--port <number>', `Dev server port (default: app.config.ts dev.server.port or ${DEV_SERVER_PORT})`)
+  .option('--host <host>', 'Dev server host (e.g. 127.0.0.1)')
   .action(async opts => {
     const cwd = process.cwd();
-    const port = Number.parseInt(String(opts.port), 10);
+    const rawPort = opts.port === undefined ? undefined : Number.parseInt(String(opts.port), 10);
+    if (opts.port !== undefined && !Number.isFinite(rawPort)) {
+      throw new Error(`Invalid --port value: ${opts.port}`);
+    }
     await devProject({
       cwd,
       configFile: opts.config,
-      port: Number.isFinite(port) ? port : undefined,
+      port: rawPort,
+      host: opts.host,
     });
   });
 

--- a/packages/sparkling-app-cli/src/types.ts
+++ b/packages/sparkling-app-cli/src/types.ts
@@ -41,6 +41,15 @@ export type PluginConfig =
 
 export interface AppConfig {
   lynxConfig: LynxConfig;
+  /** Sparkling CLI dev settings. */
+  dev?: {
+    server?: {
+      /** Preferred dev server port for sparkling-app-cli dev/run commands. Defaults to 5969. */
+      port?: number;
+      /** Preferred dev server host for sparkling-app-cli dev command. */
+      host?: string;
+    };
+  };
   appName?: string;
   platform?: PlatformConfig;
   paths?: {

--- a/packages/sparkling-app-cli/src/utils/dev-server.ts
+++ b/packages/sparkling-app-cli/src/utils/dev-server.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 TikTok Pte. Ltd.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { DEV_SERVER_PORT } from '../constants';
+import { ui } from './ui';
+import { isVerboseEnabled, verboseLog } from './verbose';
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function pingDevServer(port: number): Promise<boolean> {
+  const hosts = ['127.0.0.1', 'localhost'];
+  for (const host of hosts) {
+    if (await pingDevServerHost(host, port)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+async function pingDevServerHost(host: string, port: number): Promise<boolean> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 1000);
+  try {
+    await fetch(`http://${host}:${port}/`, {
+      method: 'GET',
+      signal: controller.signal,
+    });
+    return true;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function isDevServerRunning(port = DEV_SERVER_PORT): Promise<boolean> {
+  return pingDevServer(port);
+}
+
+export async function ensureDevServerRunning(cwd: string, port = DEV_SERVER_PORT, host = '127.0.0.1'): Promise<void> {
+  if (await isDevServerRunning(port)) {
+    if (isVerboseEnabled()) {
+      verboseLog(`Detected running sparkling dev server on port ${port}.`);
+    }
+    return;
+  }
+
+  const cliEntry = process.argv[1];
+  if (!cliEntry) {
+    throw new Error('Unable to determine sparkling-app-cli entry script from argv.');
+  }
+
+  const cliPath = path.resolve(cliEntry);
+  console.log(ui.info(`No sparkling dev server found on port ${port}; starting one...`));
+
+  const isDarwin = process.platform === 'darwin';
+  const command = isDarwin ? 'script' : process.execPath;
+  const args = isDarwin
+    ? ['-q', '/dev/null', process.execPath, cliPath, 'dev', '--port', String(port), '--host', host]
+    : [cliPath, 'dev', '--port', String(port), '--host', host];
+
+  const child = spawn(command, args, {
+    cwd,
+    detached: true,
+    stdio: 'ignore',
+    env: process.env,
+  });
+  child.unref();
+
+  for (let i = 0; i < 30; i += 1) {
+    if (await isDevServerRunning(port)) {
+      console.log(ui.success(`Sparkling dev server is running on port ${port}.`));
+      return;
+    }
+    await sleep(500);
+  }
+
+  console.warn(ui.warn(
+    `Timed out waiting for sparkling dev server on port ${port}. ` +
+    'run:ios/run:android will continue, but localhost bundle loading may fail.',
+  ));
+}

--- a/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/hybridkit/scheme/SparklingUriParser.kt
+++ b/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/hybridkit/scheme/SparklingUriParser.kt
@@ -38,6 +38,10 @@ object SparklingUriParser {
             queryMap.putAll(bundleToMap(bundle))
         }
 
+        // SECURITY: The nested "url" query parameter is parsed and its query keys are merged
+        // into queryMap without scheme validation. A malicious deep link could inject a
+        // javascript:, file:, or data: URL here. Callers that consume these merged parameters
+        // to load resources should enforce an https-only allowlist before use.
         runCatching {
             var url = uri.safeGetQueryParameter("url")
             if (url == null) {

--- a/template/sparkling-app-template/README.md
+++ b/template/sparkling-app-template/README.md
@@ -1,0 +1,47 @@
+# sparkling-app-template
+
+This template supports both local-bundle and remote-bundle workflows in development.
+
+## Dev Server Port
+
+Configure the preferred port in `app.config.ts`:
+
+```ts
+export default {
+  dev: {
+    server: {
+      port: 5969,
+    },
+  },
+}
+```
+
+`sparkling dev --port <number>` will update `dev.server.port` automatically.
+
+## Debug Bundle Source (Local or Remote)
+
+In **Debug** builds, the dev URL input supports two forms:
+
+- Remote URL: `http://127.0.0.1:5969/main.lynx.bundle`
+- Local bundle: `main.lynx.bundle`
+
+Behavior:
+
+- `http(s)://...` -> app loads with `url=...`
+- `*.lynx.bundle` (or other non-http value) -> app loads with `bundle=...`
+
+## Android Host Selection During `run:android`
+
+`sparkling run:android` automatically picks host behavior:
+
+- Emulator: uses `127.0.0.1` and applies `adb reverse tcp:<port> tcp:<port>`
+- Physical device: injects your local LAN IPv4
+
+## Release Behavior
+
+Release builds do not rely on debug-tool configuration.
+
+- iOS Release: loads from `bundle=...` only
+- Android Release: loads from `bundle=...` only
+
+That means release packages read Lynx bundles from app assets/resources, not remote dev URLs.

--- a/template/sparkling-app-template/android/app/build.gradle.kts
+++ b/template/sparkling-app-template/android/app/build.gradle.kts
@@ -19,6 +19,14 @@ android {
         ndk {
             abiFilters.addAll(listOf("armeabi-v7a", "arm64-v8a"))
         }
+
+        val sparklingDevServerHost =
+            (project.findProperty("sparklingDevServerHost") as String?) ?: "127.0.0.1"
+        val sparklingDevServerPort =
+            (project.findProperty("sparklingDevServerPort") as String?) ?: "5969"
+        buildConfigField("String", "SPARKLING_DEV_SERVER_HOST", "\"$sparklingDevServerHost\"")
+        buildConfigField("int", "SPARKLING_DEV_SERVER_PORT", sparklingDevServerPort)
+
         buildTypes {
             release {
                 isMinifyEnabled = false
@@ -74,7 +82,9 @@ android {
 
         // BEGIN SPARKLING AUTOLINK
         listOf(
-            project(":sparkling-navigation")
+            project(":sparkling-media"),
+            project(":sparkling-navigation"),
+            project(":sparkling-storage")
         ).forEach { dep -> add("implementation", dep) }
         debugImplementation(project(":sparkling-debug-tool"))
         // END SPARKLING AUTOLINK

--- a/template/sparkling-app-template/android/app/src/main/AndroidManifest.xml
+++ b/template/sparkling-app-template/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
 
     <application
         android:name="com.example.sparkling.go.SparklingApplication"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/template/sparkling-app-template/android/app/src/main/java/com/example/sparkling/go/BuiltinTemplateProvider.kt
+++ b/template/sparkling-app-template/android/app/src/main/java/com/example/sparkling/go/BuiltinTemplateProvider.kt
@@ -5,16 +5,38 @@ package com.example.sparkling.go
 
 import android.content.Context
 import com.lynx.tasm.provider.AbsTemplateProvider
+import okhttp3.OkHttpClient
+import okhttp3.Request
 import java.io.ByteArrayOutputStream
 import java.io.IOException
 
 class BuiltinTemplateProvider(context: Context) : AbsTemplateProvider() {
 
     private var mContext: Context = context.applicationContext
+    private val httpClient = OkHttpClient()
 
     override fun loadTemplate(uri: String, callback: Callback) {
         Thread {
             try {
+                // Debug mode supports remote HTTP bundle URLs as well as local asset bundles.
+                // Release paths use bundle=... and therefore stay on assets only.
+                if (isRemoteUrl(uri)) {
+                    val request = Request.Builder().url(uri).get().build()
+                    httpClient.newCall(request).execute().use { response ->
+                        if (!response.isSuccessful) {
+                            callback.onFailed("HTTP ${response.code}")
+                            return@Thread
+                        }
+                        val bytes = response.body?.bytes()
+                        if (bytes == null) {
+                            callback.onFailed("empty response body")
+                            return@Thread
+                        }
+                        callback.onSuccess(bytes)
+                    }
+                    return@Thread
+                }
+
                 mContext.assets.open(uri).use { inputStream ->
                     ByteArrayOutputStream().use { byteArrayOutputStream ->
                         val buffer = ByteArray(1024)
@@ -29,5 +51,10 @@ class BuiltinTemplateProvider(context: Context) : AbsTemplateProvider() {
                 callback.onFailed(e.message)
             }
         }.start()
+    }
+
+    private fun isRemoteUrl(uri: String): Boolean {
+        val value = uri.trim().lowercase()
+        return value.startsWith("http://") || value.startsWith("https://")
     }
 }

--- a/template/sparkling-app-template/android/app/src/main/java/com/example/sparkling/go/DebugDevUrlSupport.kt
+++ b/template/sparkling-app-template/android/app/src/main/java/com/example/sparkling/go/DebugDevUrlSupport.kt
@@ -17,21 +17,33 @@ import com.tiktok.sparkling.SparklingContext
 import com.tiktok.sparkling.SparklingUIProvider
 import com.tiktok.sparkling.debugtool.SparklingDebugTool
 
-private const val DEFAULT_MAIN_DEV_BUNDLE_URL = "http://10.0.2.2:5969/main.lynx.bundle"
+private val DEFAULT_MAIN_DEV_BUNDLE_URL: String
+    get() = "http://${BuildConfig.SPARKLING_DEV_SERVER_HOST}:${BuildConfig.SPARKLING_DEV_SERVER_PORT}/main.lynx.bundle"
 
 object DebugDevUrlSupport {
-    fun currentMainBundleUrl(context: Context): String {
+    // Debug input supports both remote URL and local bundle source.
+    // Examples:
+    // - http://127.0.0.1:5969/main.lynx.bundle
+    // - main.lynx.bundle
+    fun currentMainBundleSource(context: Context): String {
         return SparklingDebugTool.getDevUrl(context, DEFAULT_MAIN_DEV_BUNDLE_URL)
     }
 
     fun buildMainPageScheme(context: Context): String {
-        val url = currentMainBundleUrl(context)
-        return buildMainPageSchemeWithUrl(url)
+        val source = currentMainBundleSource(context)
+        return buildMainPageSchemeWithSource(source)
     }
 
-    fun buildMainPageSchemeWithUrl(url: String): String {
-        val encoded = Uri.encode(url.trim())
-        return "hybrid://lynxview_page?url=$encoded&hide_nav_bar=1&screen_orientation=portrait"
+    fun buildMainPageSchemeWithSource(source: String): String {
+        val normalized = source.trim()
+        val encoded = Uri.encode(normalized)
+        // Remote source -> url=..., local source -> bundle=...
+        val isRemote = normalized.startsWith("http://") || normalized.startsWith("https://")
+        return if (isRemote) {
+            "hybrid://lynxview_page?url=$encoded&hide_nav_bar=1&screen_orientation=portrait"
+        } else {
+            "hybrid://lynxview_page?bundle=$encoded&hide_nav_bar=1&screen_orientation=portrait"
+        }
     }
 
     fun networkBundleUrlFromScheme(scheme: String?): String? {
@@ -105,7 +117,7 @@ private class DebugDevUrlErrorView(
 
         SparklingDebugTool.showDevUrlDialog(activity, currentUrl) { updatedUrl ->
             val nextContext = SparklingContext().apply {
-                scheme = DebugDevUrlSupport.buildMainPageSchemeWithUrl(updatedUrl)
+                scheme = DebugDevUrlSupport.buildMainPageSchemeWithSource(updatedUrl)
                 withInitData(initialDataJson)
                 sparklingUIProvider = DebugSparklingUiProvider(initialDataJson, scheme ?: "")
             }

--- a/template/sparkling-app-template/app.config.ts
+++ b/template/sparkling-app-template/app.config.ts
@@ -30,6 +30,11 @@ const lynxConfig = defineConfig({
 
 const config: AppConfig = {
   lynxConfig,
+  dev: {
+    server: {
+      port: 5969,
+    },
+  },
   devtool: true,
   appName: '{{appName}}',
   platform: {

--- a/template/sparkling-app-template/ios/SparklingGo/SparklingGo/DebugDevURLSupport.swift
+++ b/template/sparkling-app-template/ios/SparklingGo/SparklingGo/DebugDevURLSupport.swift
@@ -9,16 +9,37 @@ import UIKit
 import DebugTool
 #endif
 
-private let defaultMainDevBundleURL = "http://localhost:5969/main.lynx.bundle"
-
 enum DebugDevURLSupport {
+    private static let defaultHost = "127.0.0.1"
+    private static let defaultPort = 5969
+    private static let defaultPath = "/main.lynx.bundle"
+
+    private static func fallbackDevURL() -> String {
+        let env = ProcessInfo.processInfo.environment
+        let host = env["SPARKLING_DEV_SERVER_HOST"] ?? defaultHost
+        let port = Int(env["SPARKLING_DEV_SERVER_PORT"] ?? "") ?? defaultPort
+        return "http://\(host):\(port)\(defaultPath)"
+    }
+
     static func mainScheme() -> String {
         #if DEBUG
-        let url = storedDevURL(fallback: defaultMainDevBundleURL)
-        return mainScheme(withDebugURL: url)
+        let source = storedDevURL(fallback: fallbackDevURL())
+        return mainScheme(withSource: source)
         #else
         return "hybrid://lynxview?bundle=.%2Fmain.lynx.bundle&hide_status_bar=1&hide_nav_bar=1"
         #endif
+    }
+
+    static func mainScheme(withSource source: String) -> String {
+        let normalized = source.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Debug source accepts both remote URL and local bundle name.
+        // - http(s)://... -> url=...
+        // - main.lynx.bundle -> bundle=...
+        if normalized.hasPrefix("http://") || normalized.hasPrefix("https://") {
+            return mainScheme(withDebugURL: normalized)
+        }
+        let encodedBundle = normalized.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? normalized
+        return "hybrid://lynxview?bundle=\(encodedBundle)&hide_status_bar=1&hide_nav_bar=1"
     }
 
     static func mainScheme(withDebugURL url: String) -> String {
@@ -65,7 +86,7 @@ enum DebugDevURLSupport {
         #if canImport(DebugTool)
         SparklingDebugTool.showDevURLDialog(from: controller, initialURL: initialURL, onSaved: onSaved)
         #else
-        onSaved(initialURL ?? defaultMainDevBundleURL)
+        onSaved(initialURL ?? fallbackDevURL())
         #endif
     }
 }
@@ -96,7 +117,7 @@ final class DevURLLoadFailedDelegate: NSObject, SPKContainerLifecycleProtocol {
                 return
             }
             self.isPrompting = false
-            let nextScheme = DebugDevURLSupport.mainScheme(withDebugURL: updatedURL)
+            let nextScheme = DebugDevURLSupport.mainScheme(withSource: updatedURL)
             let nextContext = DebugDevURLSupport.makeContext(delegate: self)
             let nextVC = SPKRouter.create(withURL: nextScheme, context: nextContext, frame: self.frameProvider())
             navigationController.setViewControllers([nextVC], animated: false)


### PR DESCRIPTION
This PR includes:

1. feat(cli): auto-start dev server when running on Android/iOS
2. fix(cli): fix some sparkling-app-cli issues
3. feat(template): update sparkling-app-template & playground

Closes #36