### PR TITLE
feat(sdk): add sparklingVersion to globalProps alongside lynxSdkVersion (rebase of #55)

### DIFF
--- a/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/hybridkit/config/RuntimeInfo.kt
+++ b/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/hybridkit/config/RuntimeInfo.kt
@@ -19,6 +19,9 @@ open class RuntimeInfo() : ConcurrentHashMap<String, Any>() {
         const val APP_LANGUAGE = "appLanguage"
         const val APP_LOCALE = "appLocale"
         const val LYNX_SDK_VERSION = "lynxSdkVersion"
+        const val SPARKLING_VERSION = "sparklingVersion"
+        /** Hardcoded SDK version — update during release workflow. */
+        const val SPARKLING_VERSION_VALUE = "1.0.0"
         const val STATUS_BAR_HEIGHT = "statusBarHeight"
         const val SAFEAREA_HEIGHT = "safeAreaHeight"
         const val TEMPLATE_RES_DATA = "templateResData"

--- a/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/hybridkit/utils/GlobalPropsUtils.kt
+++ b/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/hybridkit/utils/GlobalPropsUtils.kt
@@ -37,6 +37,7 @@ class GlobalPropsUtils {
 
         val builtInStableFields = mapOf<String, () -> Any>(
             RuntimeInfo.LYNX_SDK_VERSION to { LynxEnv.inst().lynxVersion },
+            RuntimeInfo.SPARKLING_VERSION to { RuntimeInfo.SPARKLING_VERSION_VALUE },
             RuntimeInfo.SCREEN_WIDTH to {
                 DevicesUtil.px2dp(
                     DevicesUtil.getScreenWidth(HybridEnvironment.instance.context).toDouble(),

--- a/packages/sparkling-sdk/ios/Sparkling/Service/LynxService/SPKLynxKitUtils.swift
+++ b/packages/sparkling-sdk/ios/Sparkling/Service/LynxService/SPKLynxKitUtils.swift
@@ -109,6 +109,7 @@ open class SPKLynxKitUtils: SPKKitUtils {
         let queryItems = params.queryItems ?? [:]
         
         globalPropos.updateValue(LynxVersion.versionString() ?? "", forKey: "lynxSdkVersion")
+        globalPropos.updateValue(SPKVersion.SPKVersion(), forKey: "sparklingVersion")
         globalPropos.updateValue(queryItems, forKey: "queryItems")
         globalPropos.updateValue(params.context?.originURL ?? "", forKey: "originUrl")
         globalPropos.updateValue(params.context?.fullURL ?? params.context?.originURL ?? "", forKey: "fullUrl")

--- a/packages/sparkling-types/src/index.ts
+++ b/packages/sparkling-types/src/index.ts
@@ -173,8 +173,11 @@ declare module '@lynx-js/types' {
     /** Timestamp (as string) when the container was initialized. */
     containerInitTime: string;
 
-    /** Version of the underlying Lynx SDK. */
+    /** Version of the underlying Lynx SDK (e.g. `"3.6.0"`). */
     lynxSdkVersion: string;
+
+    /** Version of the Sparkling SDK (e.g. `"1.0.0"`). */
+    sparklingVersion: string;
 
     /**
      * Template resource data passed to the container.


### PR DESCRIPTION
## Summary

This is a rebased version of #55, containing only the actual changes from that PR.

`lynxSdkVersion` in globalProps contains the Lynx engine version (via `LynxVersion.versionString()` / `LynxEnv.inst().lynxVersion`) but the key name is ambiguous — it could be mistaken for the Sparkling SDK version.

Add `sparklingVersion` as the Sparkling SDK version, keeping `lynxSdkVersion` unchanged for backward compatibility.

| Key | Value | Source |
|-----|-------|--------|
| `lynxSdkVersion` (existing) | `"3.6.0"` | Lynx engine |
| `sparklingVersion` (new) | `"1.0.0"` | Sparkling SDK |

**Changes:**
- **iOS**: `SPKLynxKitUtils.defaultGlobalProps()` — add `sparklingVersion` from `SPKVersion.SPKVersion()` (already exists in SDK)
- **Android**: `RuntimeInfo` — add `SPARKLING_VERSION` key + `SPARKLING_VERSION_VALUE` constant; `GlobalPropsUtils` — wire into `builtInStableFields`
- **TypeScript**: `GlobalProps` interface — add `sparklingVersion: string`

## Related PRs

- Supersedes: #55 (this is a clean rebase of that PR, excluding unrelated changes)

## Test plan
- [ ] iOS: check `lynx.__globalProps.sparklingVersion` returns `"1.0.0"` 
- [ ] Android: check `lynx.__globalProps.sparklingVersion` returns `"1.0.0"`
- [ ] Verify `lynx.__globalProps.lynxSdkVersion` still returns the Lynx engine version (no regression)
