### PR TITLE
fix(ci): unify Node.js version across workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
       #   if: needs.changes.outputs.any_unit_tests == 'true'
       #   uses: actions/setup-node@v4
       #   with:
-      #     node-version: 22
+      #     node-version: 22.21.1
       #     cache: pnpm
       #
       # - name: Install dependencies

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -17,6 +17,9 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
+env:
+  NODE_VERSION: '22.21.1'
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -27,7 +30,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/publish-release-resume.yml
+++ b/.github/workflows/publish-release-resume.yml
@@ -52,6 +52,10 @@ permissions:
   pull-requests: write
   id-token: write
 
+env:
+  NODE_VERSION: '22.21.1'
+  PNPM_VERSION: '10.26.0'
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.version }}
   cancel-in-progress: false
@@ -112,7 +116,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
 
       - name: Ensure latest npm
@@ -197,7 +201,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
 
       - name: Ensure latest npm
@@ -207,7 +211,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 10.26.0
+          version: ${{ env.PNPM_VERSION }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -432,7 +436,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
 
       - name: Ensure latest npm
@@ -441,7 +445,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 10.26.0
+          version: ${{ env.PNPM_VERSION }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -17,7 +17,7 @@ permissions:
   id-token: write
 
 env:
-  NODE_VERSION: '22'
+  NODE_VERSION: '22.21.1'
   PNPM_VERSION: '10.26.0'
   NPM_REGISTRY_URL: 'https://registry.npmjs.org'
 


### PR DESCRIPTION
## Summary
- pin CI Node.js runtime to `22.21.1` across release and website workflows to avoid runner patch regressions
- update `deploy-website` from Node 20 to the shared pinned version so it matches workspace engine requirements
- centralize `NODE_VERSION`/`PNPM_VERSION` usage in resume publish workflow for consistent setup behavior