### PR TITLE
docs(readme): refine maintainer profile display names

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ Please refer to our [contributing guide][contributing] for details.
 ## Maintainers
 | Role | Github |
 | --- | --- |
-| Creator & Lead Maintainer | [@kyrieleee](https://github.com/kyrieleee) |
+| Creator & Lead Maintainer | [@Kunyang Lee](https://github.com/leeekyrie) |
 | Lead Maintainer | [@HuxPro](https://github.com/HuxPro) |
 | Core Maintainer | [@ChenJr](https://github.com/ChenJr) |
-| Core Contributor | [@zhangyujie9999](https://github.com/zhangyujie9999) |
+| Core Contributor | [@Yujie Zhang](https://github.com/zhangyujie9999) |
 
 For bug reports, feature requests, and maintenance discussions, please open an issue in this repository.
 


### PR DESCRIPTION
## Summary
- update the maintainer table display names in the root README
- keep existing role structure and GitHub profile links intact
- preserve the issue-based contact guidance in the Maintainers section