### PR TITLE
fix(template): make Android release buildable and reduce APK size

### DIFF
--- a/template/sparkling-app-template/android/app/build.gradle.kts
+++ b/template/sparkling-app-template/android/app/build.gradle.kts
@@ -8,6 +8,15 @@ android {
     namespace = "com.example.sparkling.go"
     compileSdk = 34
 
+    splits {
+        abi {
+            isEnable = true
+            reset()
+            include("armeabi-v7a", "arm64-v8a")
+            isUniversalApk = false
+        }
+    }
+
     defaultConfig {
         applicationId = "com.example.sparkling.go"
         minSdk = 24
@@ -16,10 +25,6 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        ndk {
-            abiFilters.addAll(listOf("armeabi-v7a", "arm64-v8a"))
-        }
-
         val sparklingDevServerHost =
             (project.findProperty("sparklingDevServerHost") as String?) ?: "127.0.0.1"
         val sparklingDevServerPort =
@@ -29,7 +34,8 @@ android {
 
         buildTypes {
             release {
-                isMinifyEnabled = false
+                isMinifyEnabled = true
+                isShrinkResources = true
                 proguardFiles(
                     getDefaultProguardFile("proguard-android-optimize.txt"),
                     "proguard-rules.pro",
@@ -68,7 +74,12 @@ android {
         androidTestImplementation(libs.androidx.junit)
         androidTestImplementation(libs.androidx.espresso.core)
 
-        implementation("com.tiktok.sparkling:sparkling:2.1.0-rc.12")
+        implementation("com.tiktok.sparkling:sparkling:2.1.0-rc.12") {
+            exclude(group = "org.lynxsdk.lynx", module = "lynx-service-devtool")
+            exclude(group = "org.lynxsdk.lynx", module = "lynx-devtool")
+            exclude(group = "org.lynxsdk.lynx", module = "debug-router")
+            exclude(group = "org.lynxsdk.lynx", module = "base-devtool")
+        }
         implementation("com.tiktok.sparkling:sparkling-method:2.1.0-rc.12")
         implementation("com.squareup.okhttp3:okhttp:4.9.0")
 

--- a/template/sparkling-app-template/android/app/src/main/java/com/example/sparkling/go/DebugDevUrlSupport.kt
+++ b/template/sparkling-app-template/android/app/src/main/java/com/example/sparkling/go/DebugDevUrlSupport.kt
@@ -15,7 +15,6 @@ import androidx.appcompat.widget.Toolbar
 import com.tiktok.sparkling.Sparkling
 import com.tiktok.sparkling.SparklingContext
 import com.tiktok.sparkling.SparklingUIProvider
-import com.tiktok.sparkling.debugtool.SparklingDebugTool
 
 private val DEFAULT_MAIN_DEV_BUNDLE_URL: String
     get() = "http://${BuildConfig.SPARKLING_DEV_SERVER_HOST}:${BuildConfig.SPARKLING_DEV_SERVER_PORT}/main.lynx.bundle"
@@ -26,7 +25,7 @@ object DebugDevUrlSupport {
     // - http://127.0.0.1:5969/main.lynx.bundle
     // - main.lynx.bundle
     fun currentMainBundleSource(context: Context): String {
-        return SparklingDebugTool.getDevUrl(context, DEFAULT_MAIN_DEV_BUNDLE_URL)
+        return SparklingDebugBridge.getDevUrl(context, DEFAULT_MAIN_DEV_BUNDLE_URL)
     }
 
     fun buildMainPageScheme(context: Context): String {
@@ -115,7 +114,7 @@ private class DebugDevUrlErrorView(
         val currentUrl = DebugDevUrlSupport.networkBundleUrlFromScheme(currentScheme) ?: return
         prompted = true
 
-        SparklingDebugTool.showDevUrlDialog(activity, currentUrl) { updatedUrl ->
+        SparklingDebugBridge.showDevUrlDialog(activity, currentUrl) { updatedUrl ->
             val nextContext = SparklingContext().apply {
                 scheme = DebugDevUrlSupport.buildMainPageSchemeWithSource(updatedUrl)
                 withInitData(initialDataJson)

--- a/template/sparkling-app-template/android/app/src/main/java/com/example/sparkling/go/SparklingApplication.kt
+++ b/template/sparkling-app-template/android/app/src/main/java/com/example/sparkling/go/SparklingApplication.kt
@@ -16,7 +16,6 @@ import com.tiktok.sparkling.hybridkit.HybridKit
 import com.tiktok.sparkling.hybridkit.config.BaseInfoConfig
 import com.tiktok.sparkling.hybridkit.config.SparklingHybridConfig
 import com.tiktok.sparkling.hybridkit.config.SparklingLynxConfig
-import com.tiktok.sparkling.debugtool.SparklingDebugTool
 import com.tiktok.sparkling.method.registry.core.SparklingBridgeManager
 import com.tiktok.sparkling.method.router.close.RouterCloseMethod
 import com.tiktok.sparkling.method.router.open.RouterOpenMethod
@@ -41,7 +40,7 @@ class SparklingApplication : Application() {
 
     private fun initSparkling() {
         if (BuildConfig.DEBUG) {
-            SparklingDebugTool.init(this)
+            SparklingDebugBridge.init(this)
         }
         initHybridKit()
         initSparklingMethods()

--- a/template/sparkling-app-template/android/app/src/main/java/com/example/sparkling/go/SparklingDebugBridge.kt
+++ b/template/sparkling-app-template/android/app/src/main/java/com/example/sparkling/go/SparklingDebugBridge.kt
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 TikTok Pte. Ltd.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+package com.example.sparkling.go
+
+import android.app.Activity
+import android.app.Application
+import android.content.Context
+import kotlin.jvm.functions.Function1
+
+object SparklingDebugBridge {
+    private const val DEBUG_TOOL_CLASS = "com.tiktok.sparkling.debugtool.SparklingDebugTool"
+
+    fun init(application: Application) {
+        runCatching {
+            val debugToolClass = Class.forName(DEBUG_TOOL_CLASS)
+            val initMethod = debugToolClass.getMethod("init", Application::class.java)
+            initMethod.invoke(null, application)
+        }
+    }
+
+    fun getDevUrl(context: Context, fallback: String): String {
+        return runCatching {
+            val debugToolClass = Class.forName(DEBUG_TOOL_CLASS)
+            val getDevUrlMethod = debugToolClass.getMethod(
+                "getDevUrl",
+                Context::class.java,
+                String::class.java,
+            )
+            getDevUrlMethod.invoke(null, context, fallback) as? String ?: fallback
+        }.getOrDefault(fallback)
+    }
+
+    fun showDevUrlDialog(
+        activity: Activity,
+        initialUrl: String?,
+        onSaved: (String) -> Unit,
+    ) {
+        runCatching {
+            val debugToolClass = Class.forName(DEBUG_TOOL_CLASS)
+            val showDevUrlDialogMethod = debugToolClass.getMethod(
+                "showDevUrlDialog",
+                Activity::class.java,
+                String::class.java,
+                Function1::class.java,
+            )
+            val callback = object : Function1<String, Unit> {
+                override fun invoke(updatedUrl: String) {
+                    onSaved(updatedUrl)
+                }
+            }
+            showDevUrlDialogMethod.invoke(null, activity, initialUrl, callback)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace direct Android `SparklingDebugTool` references with a reflection bridge so release builds compile without debug-only classes on the classpath
- exclude release-side Lynx devtool dependencies and enable release minify, resource shrinking, and ABI split packaging in the template app
- validate the optimized release app on Android emulator: install, launch, offline asset loading, main/second page navigation, and close flow

## Validation
- `pnpm build`
- `./android/gradlew -p ./android assembleRelease`
- `./android/gradlew -p ./android clean assembleRelease`
- signed and installed the arm64 release APK on emulator, then verified launch and navigation behavior
- measured release APK sizes after optimization:
  - `app-arm64-v8a-release-unsigned.apk`: 12.00 MB
  - `app-armeabi-v7a-release-unsigned.apk`: 7.84 MB