### PR TITLE
opt[CI][iOS]: use version instead of node_module.

### DIFF
--- a/.github/actions/publish-ios/action.yml
+++ b/.github/actions/publish-ios/action.yml
@@ -46,7 +46,6 @@ runs:
         tag: ${{ inputs.version }}
         name: Release ${{ inputs.version }}
         token: ${{ inputs.github_token }}
-        draft: ${{ inputs.is_rc == 'true' }}
         prerelease: ${{ inputs.is_rc == 'true' }}
         generateReleaseNotes: true
         artifacts: dist/ios/*.zip

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -545,16 +545,50 @@ jobs:
       - name: Install template npm dependencies
         working-directory: template/sparkling-app-template
         run: |
-          echo "📦 Installing template dependencies (methods + tooling)..."
+          echo "📦 Installing template dependencies (JS tooling)..."
           pnpm install --no-frozen-lockfile
           echo "✅ Template npm dependencies installed"
-          echo "   node_modules/sparkling-method/ios exists: $(test -d node_modules/sparkling-method/ios && echo yes || echo no)"
+
+      - name: Wait for iOS pods on CocoaPods trunk
+        run: |
+          VERSION="${{ needs.prepare.outputs.version }}"
+          echo "⏳ Waiting for iOS pods on CocoaPods trunk (max 10 minutes, every 30s)..."
+
+          mapfile -t PODS < <(jq -r '.[] | select(.trunk == true) | .pod_name' scripts/ios_pods.json)
+
+          ALL_FOUND=true
+          for pod in "${PODS[@]}"; do
+            FOUND=false
+
+            for i in {1..20}; do
+              if bundle exec pod trunk info "$pod" 2>/dev/null | grep -q "$VERSION"; then
+                echo "✅ $pod $VERSION is indexed on trunk (after $i checks)"
+                FOUND=true
+                break
+              fi
+
+              echo "Waiting for $pod $VERSION... ($i/20, next check in 30s)"
+              sleep 30
+            done
+
+            if [ "$FOUND" != "true" ]; then
+              echo "::error::$pod $VERSION not found on CocoaPods trunk after 10 minutes"
+              ALL_FOUND=false
+            fi
+          done
+
+          if [ "$ALL_FOUND" != "true" ]; then
+            exit 1
+          fi
+
+          echo "✅ All pods indexed on trunk. Waiting 90s for CDN propagation..."
+          sleep 90
 
       - name: Verify template iOS pod install
         working-directory: template/sparkling-app-template/ios
         run: |
           echo "🔨 Verifying template iOS pod install..."
-          echo "   Sparkling resolved from CocoaPods trunk; SparklingMethod from node_modules via :path"
+          echo "   All Sparkling pods resolved from CocoaPods trunk"
           bundle exec pod install --repo-update
           echo "✅ Template iOS pod install succeeded"
 
@@ -747,8 +781,7 @@ jobs:
             - `com.tiktok.sparkling:sparkling`
             - `com.tiktok.sparkling:sparkling-method`
           - **iOS** (`template/sparkling-app-template/ios/Podfile`):
-            - `Sparkling` pod pinned to release version from CocoaPods trunk
-            - `SparklingMethod` resolved from `node_modules` via `:path`
+            - All Sparkling pods (`Sparkling`, `SparklingMethod`, `Sparkling-DebugTool`, `Sparkling-Router`) pinned to release version from CocoaPods trunk
           - **Root & SDK versions** aligned
 
           > This PR was created automatically by GitHub Actions.

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -554,7 +554,10 @@ jobs:
           VERSION="${{ needs.prepare.outputs.version }}"
           echo "⏳ Waiting for iOS pods on CocoaPods trunk (max 10 minutes, every 30s)..."
 
-          mapfile -t PODS < <(jq -r '.[] | select(.trunk == true) | .pod_name' scripts/ios_pods.json)
+          PODS=()
+          while IFS= read -r pod; do
+            PODS+=("$pod")
+          done < <(jq -r '.[] | select(.trunk == true) | .pod_name' scripts/ios_pods.json)
 
           ALL_FOUND=true
           for pod in "${PODS[@]}"; do

--- a/scripts/update-all-version.sh
+++ b/scripts/update-all-version.sh
@@ -225,17 +225,22 @@ update_template_dependencies() {
 
     if [ -f "$template_ios_podfile" ]; then
         if [ "$DRY_RUN" = true ]; then
-            print_info "[DRY RUN] Would update Sparkling pod version in $TEMPLATE_IOS_PODFILE -> $VERSION"
+            print_info "[DRY RUN] Would update iOS Podfile Sparkling pod versions in $TEMPLATE_IOS_PODFILE -> $VERSION"
+            print_info "          Sparkling, SparklingMethod, Sparkling-DebugTool, Sparkling-Router"
         else
             sedi "s|pod 'Sparkling', '[^']*'|pod 'Sparkling', '${VERSION}'|" "$template_ios_podfile"
-            print_success "Updated Sparkling pod version in $TEMPLATE_IOS_PODFILE"
+            sedi "s|pod 'SparklingMethod', '[^']*'|pod 'SparklingMethod', '${VERSION}'|" "$template_ios_podfile"
+            sedi "s|pod 'Sparkling-DebugTool', '[^']*'|pod 'Sparkling-DebugTool', '${VERSION}'|" "$template_ios_podfile"
+            sedi "s|pod 'Sparkling-Router', '[^']*'|pod 'Sparkling-Router', '${VERSION}'|" "$template_ios_podfile"
+            print_success "Updated iOS Podfile pod versions in $TEMPLATE_IOS_PODFILE"
         fi
     else
         print_warning "File not found: $TEMPLATE_IOS_PODFILE"
     fi
 
     print_info ""
-    print_info "iOS Podfile pins Sparkling pod version directly and is updated by this script."
+    print_info "iOS Podfile pins Sparkling pod versions directly (from CocoaPods trunk) and is updated by this script."
+    print_info "After version bump, run: cd template/sparkling-app-template/ios && pod install --repo-update"
 }
 
 # Function to show Android info

--- a/template/sparkling-app-template/ios/Gemfile
+++ b/template/sparkling-app-template/ios/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 ruby '>= 3.2.6'
 gem 'cocoapods', '>= 1.14'

--- a/template/sparkling-app-template/ios/Gemfile.lock
+++ b/template/sparkling-app-template/ios/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.8)
-    activesupport (7.2.3.1)
+    activesupport (7.2.3)
       base64
       benchmark (>= 0.3)
       bigdecimal
@@ -11,10 +11,10 @@ GEM
       drb
       i18n (>= 1.6, < 2)
       logger (>= 1.4.2)
-      minitest (>= 5.1, < 6)
+      minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
-    addressable (2.9.0)
+    addressable (2.8.8)
       public_suffix (>= 2.0.2, < 8.0)
     algoliasearch (1.27.5)
       httpclient (~> 2.8, >= 2.8.3)
@@ -22,7 +22,7 @@ GEM
     atomos (0.1.3)
     base64 (0.3.0)
     benchmark (0.5.0)
-    bigdecimal (4.1.1)
+    bigdecimal (4.0.1)
     claide (1.1.0)
     cocoapods (1.16.2)
       addressable (~> 2.8)
@@ -66,9 +66,8 @@ GEM
     connection_pool (3.0.2)
     drb (2.2.3)
     escape (0.0.4)
-    ethon (0.18.0)
+    ethon (0.15.0)
       ffi (>= 1.15.0)
-      logger
     ffi (1.16.3)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
@@ -77,20 +76,22 @@ GEM
       mutex_m
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    json (2.19.3)
+    json (2.7.6)
     logger (1.7.0)
-    minitest (5.27.0)
+    minitest (6.0.1)
+      prism (~> 1.5)
     molinillo (0.8.0)
     mutex_m (0.3.0)
     nanaimo (0.4.0)
     nap (1.1.0)
     netrc (0.11.0)
+    prism (1.9.0)
     public_suffix (4.0.7)
     rexml (3.4.4)
     ruby-macho (2.5.1)
     securerandom (0.4.1)
-    typhoeus (1.6.0)
-      ethon (>= 0.18.0)
+    typhoeus (1.5.0)
+      ethon (>= 0.9.0, < 0.16.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     xcodeproj (1.27.0)
@@ -102,7 +103,10 @@ GEM
       rexml (>= 3.3.6, < 4.0)
 
 PLATFORMS
+  arm64-darwin-23
+  arm64-darwin-24
   arm64-darwin-25
+  x86_64-darwin
 
 DEPENDENCIES
   cocoapods (>= 1.14)
@@ -112,4 +116,4 @@ RUBY VERSION
    ruby 3.2.6p234
 
 BUNDLED WITH
-   2.4.19
+   2.3.27

--- a/template/sparkling-app-template/ios/Podfile
+++ b/template/sparkling-app-template/ios/Podfile
@@ -12,19 +12,18 @@ install! 'cocoapods',
 inhibit_all_warnings!
 
 def sparkling_methods
-  pod 'SparklingMethod', :path => '../node_modules/sparkling-method/ios',
-      :subspecs => ['Lynx', 'DIProvider', 'Debug']
+  pod 'SparklingMethod', '2.1.0-rc.12', :subspecs => ['Lynx', 'DIProvider', 'Debug']
 end
 
 def sparkling_methods_dep
   # BEGIN SPARKLING AUTOLINK
-  pod 'Sparkling-Router', :path => '../node_modules/sparkling-navigation/ios'
+  pod 'Sparkling-Router', '2.1.0-rc.12'
   # END SPARKLING AUTOLINK
 end
 
 def sparkling_devtool
   # BEGIN SPARKLING AUTOLINK
-  pod 'Sparkling-DebugTool', :path => '../node_modules/sparkling-debug-tool/ios'
+  pod 'Sparkling-DebugTool', '2.1.0-rc.12'
   # END SPARKLING AUTOLINK
 end
 

--- a/template/sparkling-app-template/ios/Podfile.lock
+++ b/template/sparkling-app-template/ios/Podfile.lock
@@ -133,16 +133,16 @@ PODS:
     - Sparkling/Application (= 2.1.0-rc.12)
     - Sparkling/Service (= 2.1.0-rc.12)
     - Sparkling/Utils (= 2.1.0-rc.12)
-  - Sparkling-DebugTool (2.1.0-rc.14):
+  - Sparkling-DebugTool (2.1.0-rc.12):
     - Lynx (~> 3.6.0)
     - LynxDevtool/Framework (~> 3.6.0)
     - LynxService/Devtool (~> 3.6.0)
-  - Sparkling-Router (2.1.0-rc.14):
+  - Sparkling-Router (2.1.0-rc.12):
     - Mantle (~> 2.2.0)
-    - Sparkling-Router/Core (= 2.1.0-rc.14)
+    - Sparkling-Router/Core (= 2.1.0-rc.12)
     - SparklingMethod/Core
     - SparklingMethod/DIProvider
-  - Sparkling-Router/Core (2.1.0-rc.14):
+  - Sparkling-Router/Core (2.1.0-rc.12):
     - Mantle (~> 2.2.0)
     - SparklingMethod/Core
     - SparklingMethod/DIProvider
@@ -187,12 +187,12 @@ DEPENDENCIES:
   - SDWebImage (= 5.15.5)
   - SDWebImageWebPCoder (= 0.11.0)
   - SnapKit
-  - "Sparkling (from `../node_modules/@sparklingjs/runtime/ios/Sparkling`)"
-  - Sparkling-DebugTool (from `../node_modules/sparkling-debug-tool/ios`)
-  - Sparkling-Router (from `../node_modules/sparkling-navigation/ios`)
-  - SparklingMethod/Debug (from `../node_modules/sparkling-method/ios`)
-  - SparklingMethod/DIProvider (from `../node_modules/sparkling-method/ios`)
-  - SparklingMethod/Lynx (from `../node_modules/sparkling-method/ios`)
+  - Sparkling (= 2.1.0-rc.12)
+  - Sparkling-DebugTool (= 2.1.0-rc.12)
+  - Sparkling-Router (= 2.1.0-rc.12)
+  - SparklingMethod/Debug (= 2.1.0-rc.12)
+  - SparklingMethod/DIProvider (= 2.1.0-rc.12)
+  - SparklingMethod/Lynx (= 2.1.0-rc.12)
 
 SPEC REPOS:
   trunk:
@@ -210,16 +210,10 @@ SPEC REPOS:
     - SDWebImageWebPCoder
     - SnapKit
     - SocketRocket
-
-EXTERNAL SOURCES:
-  Sparkling:
-    :path: "../node_modules/@sparklingjs/runtime/ios/Sparkling"
-  Sparkling-DebugTool:
-    :path: "../node_modules/sparkling-debug-tool/ios"
-  Sparkling-Router:
-    :path: "../node_modules/sparkling-navigation/ios"
-  SparklingMethod:
-    :path: "../node_modules/sparkling-method/ios"
+    - Sparkling
+    - Sparkling-DebugTool
+    - Sparkling-Router
+    - SparklingMethod
 
 SPEC CHECKSUMS:
   BaseDevtool: 39ad8896da6d55bfe4a2231feb85b8e0ef23e6e3
@@ -241,6 +235,6 @@ SPEC CHECKSUMS:
   Sparkling-Router: 093e97e8ded7be91c1c976d82f52a436eb9050f4
   SparklingMethod: a8da97a23b54eb3ca869abd854bfaa264cc57255
 
-PODFILE CHECKSUM: 1ac07085fe2c0a228c5d11d4408cc8f378841121
+PODFILE CHECKSUM: 463d4547103ad4eb84afdecf5eb91f55190cce4f
 
 COCOAPODS: 1.16.2


### PR DESCRIPTION
## Summary

Switch the app template's iOS Podfile from resolving Sparkling pods via `node_modules` (`:path`) to versioned references from CocoaPods trunk. This aligns iOS pod resolution with how Android resolves from Maven Central — all native dependencies come from the published registry, not from locally installed npm packages.

Also removes the `draft` flag from GitHub Releases so CocoaPods can access release assets immediately, and adds a CDN propagation wait in the verify step so `pod install` doesn't race against trunk indexing.

## Related issues

N/A

## Changes

- **`template/sparkling-app-template/ios/Podfile`**: Replace `:path => node_modules/...` with pinned version strings for `SparklingMethod`, `Sparkling-Router`, `Sparkling-DebugTool`; `Sparkling` was already versioned
- **`template/sparkling-app-template/ios/Podfile.lock`**: Remove `EXTERNAL SOURCES` block, move all Sparkling pods into `SPEC REPOS: trunk`, align `Sparkling-Router` / `Sparkling-DebugTool` versions from `rc.14` → `rc.12`, update PODFILE CHECKSUM
- **`template/sparkling-app-template/ios/Gemfile` + `Gemfile.lock`**: Move from repo root to `ios/` (where `pod install` runs), sync with root Gemfile.lock
- **`scripts/update-all-version.sh`**: Extend Podfile version bump to also update `SparklingMethod`, `Sparkling-DebugTool`, `Sparkling-Router` pod pins (previously only `Sparkling` was updated)
- **`.github/workflows/publish-release.yml`**: Add `Wait for iOS pods on CocoaPods trunk` step before `pod install` in `verify-template-ios` — polls `pod trunk info` for each pod in `scripts/ios_pods.json` (up to 10 min), then waits 90s for CDN propagation; update stale comments and PR body copy referencing the old node_modules approach
- **`.github/actions/publish-ios/action.yml`**: Remove `draft` flag from `ncipollo/release-action` so RC releases are immediately public and accessible to CocoaPods

## How to test

**Version bump script:**
```bash
./scripts/update-all-version.sh 2.1.0-rc.99 --dry-run
# Verify Podfile pod pins are listed in output for all 4 Sparkling pods
```

**Local template scaffold:**
```bash
pnpm --filter create-sparkling-app build
node packages/create-sparkling-app/bin/index.js my-app \
  --template ./template/sparkling-app-template -y
cd my-app/ios
bundle exec pod install --repo-update
# Should resolve all Sparkling pods from CocoaPods trunk, no node_modules paths
```

## Checklist
- [x] I read `CONTRIBUTING.md`.
- [ ] I linked a related issue (or explained why this is standalone).
- [x] I ran relevant checks
- [ ] I updated docs/examples (if needed).
- [ ] I added/updated tests (if applicable), or explained why not.
