### PR TITLE
opt[CI]: add CDN propagation wait and retry for iOS pod install

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -592,8 +592,21 @@ jobs:
         run: |
           echo "🔨 Verifying template iOS pod install..."
           echo "   All Sparkling pods resolved from CocoaPods trunk"
-          bundle exec pod install --repo-update
-          echo "✅ Template iOS pod install succeeded"
+
+          DELAY=60
+          for i in {1..6}; do
+            if bundle exec pod install --repo-update --verbose; then
+              echo "✅ Template iOS pod install succeeded"
+              exit 0
+            fi
+            if [ $i -eq 6 ]; then
+              echo "::error::pod install failed after 6 attempts"
+              exit 1
+            fi
+            echo "pod install failed (attempt $i/6), waiting ${DELAY}s for CDN to propagate..."
+            sleep $DELAY
+            DELAY=$((DELAY + 60))
+          done
 
   # ──────────────────────────────────────────────────────────────
   # Step 4: Publish sparkling-app-template to npm


### PR DESCRIPTION
## Summary

`pod install` in the `verify-template-ios` step can fail even after all pods are indexed on trunk, because the CocoaPods CDN may not have propagated the new specs yet. Replace the single `pod install` call with a retry loop that backs off progressively, giving the CDN time to catch up.

## Related issues

N/A

## Changes

- **`.github/workflows/publish-release.yml`**: Replace bare `pod install --repo-update` with a retry loop — up to 6 attempts (5 retries), wait time increases by 60s each retry (60 → 120 → 180 → 240 → 300s), max total wait 15 minutes; add `--verbose` for easier failure diagnosis

## How to test

Covered by the next iOS release run. If CDN propagation is slow, the step will retry automatically instead of failing immediately.

## Checklist
- [x] I read `CONTRIBUTING.md`.
- [ ] I linked a related issue (or explained why this is standalone).
- [x] I ran relevant checks
- [x] I updated docs/examples (if needed).
- [ ] I added/updated tests (if applicable), or explained why not.
