### PR TITLE
opt[ci]: add playground build checks for FE, Android, and iOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,9 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
 
+      - name: Add Android platform-tools to PATH
+        run: echo "$ANDROID_HOME/platform-tools" >> $GITHUB_PATH
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       force_all: ${{ github.event_name == 'workflow_dispatch' }}
       run_all: ${{ steps.filter.outputs.shared == 'true' || steps.filter.outputs.tooling == 'true' || github.event_name == 'workflow_dispatch' }}
       any_unit_tests: ${{ steps.filter.outputs.create_sparkling_app == 'true' || steps.filter.outputs.sparkling_method_cli == 'true' || steps.filter.outputs.sparkling_method == 'true' || steps.filter.outputs.sparkling_router == 'true' || steps.filter.outputs.sparkling_storage == 'true' || steps.filter.outputs.playground == 'true' || steps.filter.outputs.app_template == 'true' || steps.filter.outputs.shared == 'true' || steps.filter.outputs.tooling == 'true' || github.event_name == 'workflow_dispatch' }}
+      build_playground: ${{ steps.filter.outputs.playground == 'true' || steps.filter.outputs.sparkling_sdk == 'true' || steps.filter.outputs.sparkling_method == 'true' || steps.filter.outputs.sparkling_debug_tool == 'true' || steps.filter.outputs.sparkling_navigation == 'true' || steps.filter.outputs.sparkling_media == 'true' || steps.filter.outputs.sparkling_storage == 'true' || steps.filter.outputs.shared == 'true' || steps.filter.outputs.tooling == 'true' || github.event_name == 'workflow_dispatch' }}
       create_sparkling_app: ${{ steps.filter.outputs.create_sparkling_app }}
       sparkling_method_cli: ${{ steps.filter.outputs.sparkling_method_cli }}
       sparkling_method: ${{ steps.filter.outputs.sparkling_method }}
@@ -53,6 +54,14 @@ jobs:
               - 'packages/methods/sparkling-router/**'
             sparkling_storage:
               - 'packages/methods/sparkling-storage/**'
+            sparkling_sdk:
+              - 'packages/sparkling-sdk/**'
+            sparkling_debug_tool:
+              - 'packages/sparkling-debug-tool/**'
+            sparkling_navigation:
+              - 'packages/methods/sparkling-navigation/**'
+            sparkling_media:
+              - 'packages/methods/sparkling-media/**'
             playground:
               - 'packages/playground/**'
             app_template:
@@ -163,3 +172,83 @@ jobs:
       # - name: Test sparkling-app-template
       #   if: needs.changes.outputs.run_all == 'true' || needs.changes.outputs.app_template == 'true'
       #   run: pnpm --filter sparkling-app-template test
+
+  # ──────────────────────────────────────────────────────────────
+  # Playground build checks — block PR if any platform fails
+  # ──────────────────────────────────────────────────────────────
+
+  build-playground-android:
+    name: Build Playground (Android)
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.run_all == 'true' || needs.changes.outputs.build_playground == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build workspace dependencies
+        working-directory: packages/playground
+        run: pnpm build
+
+      - name: Build playground Android
+        working-directory: packages/playground
+        run: pnpm run:android
+
+  build-playground-ios:
+    name: Build Playground (iOS)
+    runs-on: macos-latest
+    needs: changes
+    if: needs.changes.outputs.run_all == 'true' || needs.changes.outputs.build_playground == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+
+      - name: Install CocoaPods
+        run: bundle install
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build workspace dependencies
+        working-directory: packages/playground
+        run: pnpm build
+
+      - name: Build playground iOS
+        working-directory: packages/playground
+        run: pnpm run:ios

--- a/packages/playground/ios/Podfile
+++ b/packages/playground/ios/Podfile
@@ -19,15 +19,16 @@ end
 
 def sparkling_methods_dep
   # BEGIN SPARKLING AUTOLINK
-  pod 'Sparkling-DebugTool', :path => '../../sparkling-debug-tool/ios'
   pod 'Sparkling-Media', :path => '../../methods/sparkling-media/ios'
-  pod 'Sparkling-Storage', :path => '../../methods/sparkling-storage/ios'
   pod 'Sparkling-Router', :path => '../../methods/sparkling-navigation/ios'
+  pod 'Sparkling-Storage', :path => '../../methods/sparkling-storage/ios'
   # END SPARKLING AUTOLINK
 end
 
 def sparkling_devtool
+  # BEGIN SPARKLING AUTOLINK
   pod 'Sparkling-DebugTool', :path => '../../sparkling-debug-tool/ios'
+  # END SPARKLING AUTOLINK
 end
 
 def sparkling_kit

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,29 +13,32 @@
     "build": "pnpm -C ../.. --filter sparkling-method --filter sparkling-navigation --filter sparkling-storage --filter sparkling-media build && rspeedy build",
     "dev": "rspeedy dev",
     "format": "prettier --write .",
-    "preview": "rspeedy preview"
+    "preview": "rspeedy preview",
+    "run:android": "sparkling-app-cli run:android",
+    "run:ios": "sparkling-app-cli run:ios --copy"
   },
   "dependencies": {
     "@lynx-js/react": "^0.116.2",
+    "sparkling-app-cli": "2.1.0-rc.12",
+    "sparkling-media": "workspace:*",
     "sparkling-navigation": "workspace:*",
-    "sparkling-storage": "workspace:*",
-    "sparkling-media": "workspace:*"
+    "sparkling-storage": "workspace:*"
   },
   "devDependencies": {
     "@lynx-js/qrcode-rsbuild-plugin": "^0.4.4",
     "@lynx-js/react-rsbuild-plugin": "^0.12.7",
     "@lynx-js/rspeedy": "^0.13.3",
     "@lynx-js/types": "^3.6.0",
-    "sparkling-types": "workspace:*",
     "@rsbuild/core": "1.7.2",
     "@testing-library/jest-dom": "^6.6.3",
     "@types/react": "^18.3.20",
+    "@vitest/coverage-v8": "^3.1.2",
     "jsdom": "^26.1.0",
     "prettier": "^3.5.3",
     "sparkling-debug-tool": "workspace:*",
+    "sparkling-types": "workspace:*",
     "typescript": "^5.8.3",
-    "vitest": "^3.1.2",
-    "@vitest/coverage-v8": "^3.1.2"
+    "vitest": "^3.1.2"
   },
   "engines": {
     "node": "^22 || ^24"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       '@lynx-js/react':
         specifier: ^0.116.2
         version: 0.116.5(@lynx-js/types@3.7.0)(@types/react@18.3.28)
+      sparkling-app-cli:
+        specifier: 2.1.0-rc.12
+        version: 2.1.0-rc.12(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@types/node@25.6.0)(typescript@5.9.3)(webpack@5.105.0)
       sparkling-media:
         specifier: workspace:*
         version: link:../methods/sparkling-media
@@ -309,7 +312,7 @@ importers:
         version: link:../../packages/sparkling-method
       sparkling-navigation:
         specifier: ~2.1.0-rc.12
-        version: 2.1.0-rc.12
+        version: link:../../packages/methods/sparkling-navigation
     devDependencies:
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: ^0.4.4
@@ -343,7 +346,7 @@ importers:
         version: 2.1.0-rc.12(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@types/node@25.6.0)(typescript@5.9.3)(webpack@5.105.0)
       sparkling-types:
         specifier: ~2.1.0-rc.12
-        version: link:../../packages/sparkling-types
+        version: 2.1.0-rc.20(@lynx-js/types@3.7.0)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -4676,11 +4679,10 @@ packages:
     resolution: {integrity: sha512-UMrfTHc/x7WfS9V5cob8uS8E/ucb2/PompUpAppqPmFQOv/Eg3KORT9Oqp0QP5JjG5HAEwe0vIi6zUiWRw38Tw==}
     engines: {node: ^22 || ^24}
 
-  sparkling-method@2.1.0-rc.12:
-    resolution: {integrity: sha512-TfSMzFS66MYJWZG4Drn5gNCMtDqkJIvVNHhVu6DIyVxjFhIgdRiXqYsDwLh8VIQlHnTQnuNmONVEtHPzsEWaFw==}
-
-  sparkling-navigation@2.1.0-rc.12:
-    resolution: {integrity: sha512-kAQ5jZsjAixrQuoCBiiojY4jNxyilrhP/ZAjg9DvCmqdOQME73rC1+BR8zax1cyxLeAaa0fxcztAS6exA78qnA==}
+  sparkling-types@2.1.0-rc.20:
+    resolution: {integrity: sha512-87Nc4fhV+IAYr6iM0QcTWWE7bZ4IdvD2Pp5u5yCgdRfetYJYIjh5e0VFNPgahWU2gLjy7FxbvAY21r+TItCbuQ==}
+    peerDependencies:
+      '@lynx-js/types': '>=3.0.0'
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -10895,11 +10897,9 @@ snapshots:
 
   sparkling-debug-tool@2.1.0-rc.14: {}
 
-  sparkling-method@2.1.0-rc.12: {}
-
-  sparkling-navigation@2.1.0-rc.12:
+  sparkling-types@2.1.0-rc.20(@lynx-js/types@3.7.0):
     dependencies:
-      sparkling-method: 2.1.0-rc.12
+      '@lynx-js/types': 3.7.0
 
   sprintf-js@1.0.3: {}
 


### PR DESCRIPTION
## Summary

Add two required CI jobs that build the Sparkling playground on Android and iOS on every PR targeting `main`. Both jobs delegate to the playground's `sparkling-app-cli` scripts (`run:android` / `run:ios`) so the full native build pipeline — autolink, compile, package — is exercised. Any failure blocks merge.

## Related issues

N/A

## Changes

- **`.github/workflows/ci.yml`**:
  - Add path filters for `sparkling_sdk`, `sparkling_debug_tool`, `sparkling_navigation`, `sparkling_media` — native packages that playground depends on
  - Add `build_playground` output aggregating all playground-relevant filters
  - Add `build-playground-android` job (ubuntu, JDK 11): `pnpm run:android` in `packages/playground`
  - Add `build-playground-ios` job (macos, Ruby 3.2 + CocoaPods): `pnpm run:ios` in `packages/playground`

## How to test

Push a PR touching any of: `packages/playground/**`, `packages/sparkling-sdk/**`, `packages/sparkling-method/**`, `packages/sparkling-debug-tool/**`, `packages/methods/sparkling-navigation/**`, `packages/methods/sparkling-media/**`, `packages/methods/sparkling-storage/**` — both build jobs should appear and must pass before merge.

> Note: add `build-playground-android` and `build-playground-ios` as **required status checks** in branch protection settings for `main` to enforce the block.

## Checklist
- [x] I read `CONTRIBUTING.md`.
- [ ] I linked a related issue (or explained why this is standalone).
- [x] I ran relevant checks
- [ ] I updated docs/examples (if needed).
- [ ] I added/updated tests (if applicable), or explained why not.
