### PR TITLE
fix: repair broken README doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Large-scale apps like TikTok are never built with a single technology. Sparkling
 
 ## Documentation
 The full documentation for Sparkling can be found in [`docs`](/docs)
-- [Get Started](./docs/en/guide/get-started/create-new-app.md)
-- [Integrate Sparkling into an existing app](./docs/en/guide/get-started/integrate-sparkling-into-existing-app.md)
+- [Get Started](./docs/en/guide/get-started/create-new-app.mdx)
+- [Integrate Sparkling into an existing app](./docs/en/guide/get-started/integrate-sparkling-into-existing-app.mdx)
 - [API Reference](./docs/en/apis/)
 
 ## Project Layout


### PR DESCRIPTION
Agent-Logs-Url: https://github.com/jianliang00/sparkling/sessions/3a12bdaa-992e-438d-9a9d-1e63ea6579a3

## Summary
<!-- What does this PR change and why? -->

## Related issues
<!-- Link issues and use keywords when applicable (e.g., Fixes #123). -->

## Changes
<!-- Bulleted list of the main changes. -->

## How to test
<!-- Provide commands and/or a short manual verification plan. -->

## Checklist
- [x] I read `CONTRIBUTING.md`.
- [ ] I linked a related issue (or explained why this is standalone).
- [ ] I ran relevant checks
- [x] I updated docs/examples (if needed).
- [ ] I added/updated tests (if applicable), or explained why not.

