### PR TITLE
fix[iOS]: LynxDevTool can not attach to running app

### DIFF
--- a/packages/playground/ios/Podfile
+++ b/packages/playground/ios/Podfile
@@ -29,6 +29,8 @@ def sparkling_devtool
   # BEGIN SPARKLING AUTOLINK
   pod 'Sparkling-DebugTool', :path => '../../sparkling-debug-tool/ios'
   # END SPARKLING AUTOLINK
+  pod 'DebugRouter', '5.0.15'
+  pod 'DebugRouter/MessageTransceiverEnable', '5.0.15'
 end
 
 def sparkling_kit
@@ -60,7 +62,16 @@ def sparkling_kit
 end
 
 use_frameworks!
+
+# SparklingGo is the production-style target: no devtool dependencies are
+# linked, so DebugRouter / LynxDevtool symbols cannot leak into a Release
+# build. Use SparklingGoInHouse for day-to-day development (it is what
+# `pnpm run:ios` builds).
 target 'SparklingGo' do
+  sparkling_kit
+end
+
+target 'SparklingGoInHouse' do
   sparkling_kit
   sparkling_devtool
 end
@@ -77,10 +88,6 @@ target 'SparklingGoUITests' do
   sparkling_kit
 end
 
-# Strip debug-tool pods from Release builds so they are debug-only.
-devtool_frameworks = ['Sparkling_DebugTool']
-devtool_pod_names = ['Sparkling-DebugTool']
-
 # Append Local.xcconfig (gitignored) to the Pods-generated xcconfigs so
 # developers can override build settings (e.g. DEVELOPMENT_TEAM) locally.
 post_install do |installer|
@@ -92,28 +99,6 @@ post_install do |installer|
       unless content.include?(include_line)
         File.open(path, 'a') { |f| f.puts "\n#{include_line}" }
       end
-    end
-  end
-
-  # 1. Exclude all source files from debug-tool pod targets in Release
-  installer.target_installation_results.pod_target_installation_results.each do |pod_name, result|
-    next unless devtool_pod_names.any? { |n| pod_name.to_s.include?(n) }
-    result.native_target.build_configurations.each do |config|
-      if config.name == 'Release'
-        config.build_settings['EXCLUDED_SOURCE_FILE_NAMES'] = '*'
-      end
-    end
-  end
-
-  # 2. Strip devtool framework references from app target linker flags in Release
-  installer.aggregate_targets.each do |aggregate_target|
-    aggregate_target.xcconfigs.each do |config_name, xcconfig|
-      next unless config_name == 'Release'
-      devtool_frameworks.each do |fw|
-        xcconfig.other_linker_flags[:frameworks].delete(fw)
-      end
-      xcconfig_path = aggregate_target.xcconfig_path(config_name)
-      xcconfig.save_as(xcconfig_path)
     end
   end
 end

--- a/packages/playground/ios/SparklingGo.xcodeproj/project.pbxproj
+++ b/packages/playground/ios/SparklingGo.xcodeproj/project.pbxproj
@@ -9,8 +9,10 @@
 /* Begin PBXBuildFile section */
 		07B2FB684B8D385782138000 /* Pods_SparklingGoUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AD74935FFBD17E3B3D4E69A /* Pods_SparklingGoUITests.framework */; };
 		90C786CC2F3D5FB6008FED78 /* LynxResources in Resources */ = {isa = PBXBuildFile; fileRef = 90C786CB2F3D5FB6008FED78 /* LynxResources */; };
+		BD26C18BAC3F8A1D14F3D51E /* Pods_SparklingGoInHouse.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A8C421A83FD99B16BD0A3E3E /* Pods_SparklingGoInHouse.framework */; };
 		CEAB8C5202B26CF8F0BE5581 /* Pods_SparklingGo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B00F0DF4C89E15C31BC93A3 /* Pods_SparklingGo.framework */; };
 		DE44680A8011EA315778F328 /* Pods_SparklingMethodTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80857B85C0422883390B2606 /* Pods_SparklingMethodTests.framework */; };
+		DF4098C8CC6BF6DB06FE60D9 /* LynxResources in Resources */ = {isa = PBXBuildFile; fileRef = 90C786CB2F3D5FB6008FED78 /* LynxResources */; };
 		E1EA18997313C777BCB28C73 /* Pods_SparklingGoTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 34294AA1E3153C7FF24DA29D /* Pods_SparklingGoTests.framework */; };
 /* End PBXBuildFile section */
 
@@ -51,10 +53,14 @@
 		8CA3C88BC922913EC94B79D5 /* Pods-SparklingGo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SparklingGo.release.xcconfig"; path = "Target Support Files/Pods-SparklingGo/Pods-SparklingGo.release.xcconfig"; sourceTree = "<group>"; };
 		90C786CB2F3D5FB6008FED78 /* LynxResources */ = {isa = PBXFileReference; lastKnownFileType = folder; path = LynxResources; sourceTree = "<group>"; };
 		9AD74935FFBD17E3B3D4E69A /* Pods_SparklingGoUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SparklingGoUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9DAB5FA9ECA8B400DB3F300A /* Pods-SparklingGoInHouse.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SparklingGoInHouse.release.xcconfig"; path = "Target Support Files/Pods-SparklingGoInHouse/Pods-SparklingGoInHouse.release.xcconfig"; sourceTree = "<group>"; };
+		A8C421A83FD99B16BD0A3E3E /* Pods_SparklingGoInHouse.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SparklingGoInHouse.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B5E42D779278857A5AAB06BF /* Pods-SparklingGoUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SparklingGoUITests.debug.xcconfig"; path = "Target Support Files/Pods-SparklingGoUITests/Pods-SparklingGoUITests.debug.xcconfig"; sourceTree = "<group>"; };
+		BDC8D2EB13B568D4F1740748 /* SparklingGoInHouse.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SparklingGoInHouse.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BEB0A8939FDC0E69DE1ACBE1 /* Pods-SparklingGoUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SparklingGoUITests.release.xcconfig"; path = "Target Support Files/Pods-SparklingGoUITests/Pods-SparklingGoUITests.release.xcconfig"; sourceTree = "<group>"; };
 		C50586CC4ECBC63F4329F466 /* Pods-SparklingMethodTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SparklingMethodTests.release.xcconfig"; path = "Target Support Files/Pods-SparklingMethodTests/Pods-SparklingMethodTests.release.xcconfig"; sourceTree = "<group>"; };
 		E28DB50001F3EFBF06162E18 /* Pods-SparklingGo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SparklingGo.debug.xcconfig"; path = "Target Support Files/Pods-SparklingGo/Pods-SparklingGo.debug.xcconfig"; sourceTree = "<group>"; };
+		F37D60B7A70AAC4EB75DD22C /* Pods-SparklingGoInHouse.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SparklingGoInHouse.debug.xcconfig"; path = "Target Support Files/Pods-SparklingGoInHouse/Pods-SparklingGoInHouse.debug.xcconfig"; sourceTree = "<group>"; };
 		FC9A690424F49FA47736FA61 /* Pods-SparklingGoTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SparklingGoTests.release.xcconfig"; path = "Target Support Files/Pods-SparklingGoTests/Pods-SparklingGoTests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -122,6 +128,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C033E9C113E1E698019BF3F4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BD26C18BAC3F8A1D14F3D51E /* Pods_SparklingGoInHouse.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -132,6 +146,7 @@
 				34294AA1E3153C7FF24DA29D /* Pods_SparklingGoTests.framework */,
 				9AD74935FFBD17E3B3D4E69A /* Pods_SparklingGoUITests.framework */,
 				80857B85C0422883390B2606 /* Pods_SparklingMethodTests.framework */,
+				A8C421A83FD99B16BD0A3E3E /* Pods_SparklingGoInHouse.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -158,6 +173,7 @@
 				44B59A982DE9042100A05B89 /* SparklingGoTests.xctest */,
 				44B59AA22DE9042100A05B89 /* SparklingGoUITests.xctest */,
 				44A4C3032E271D570011A613 /* SparklingMethodTests.xctest */,
+				BDC8D2EB13B568D4F1740748 /* SparklingGoInHouse.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -173,6 +189,8 @@
 				BEB0A8939FDC0E69DE1ACBE1 /* Pods-SparklingGoUITests.release.xcconfig */,
 				8C76000D4A2F6C5E1542B66F /* Pods-SparklingMethodTests.debug.xcconfig */,
 				C50586CC4ECBC63F4329F466 /* Pods-SparklingMethodTests.release.xcconfig */,
+				F37D60B7A70AAC4EB75DD22C /* Pods-SparklingGoInHouse.debug.xcconfig */,
+				9DAB5FA9ECA8B400DB3F300A /* Pods-SparklingGoInHouse.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -180,6 +198,29 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		0F3D1595293D70FE62E1D699 /* SparklingGoInHouse */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8B74036F7C466DCA6D698700 /* Build configuration list for PBXNativeTarget "SparklingGoInHouse" */;
+			buildPhases = (
+				BFDC12B261721A1C9F145346 /* [CP] Check Pods Manifest.lock */,
+				30FBC3F8EE5A026AC9B722C8 /* Sources */,
+				C033E9C113E1E698019BF3F4 /* Frameworks */,
+				F9F42152B9FB6FA0002CB348 /* Resources */,
+				3EAEEF4A78968ADA92CAEA6D /* [CP] Embed Pods Frameworks */,
+				8811720C0D66DA4CF5F429BA /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				44B59A892DE9041F00A05B89 /* SparklingGo */,
+			);
+			name = SparklingGoInHouse;
+			productName = SparklingGoInHouse;
+			productReference = BDC8D2EB13B568D4F1740748 /* SparklingGoInHouse.app */;
+			productType = "com.apple.product-type.application";
+		};
 		44A4C3022E271D570011A613 /* SparklingMethodTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 44A4C30B2E271D570011A613 /* Build configuration list for PBXNativeTarget "SparklingMethodTests" */;
@@ -286,6 +327,9 @@
 				LastSwiftUpdateCheck = 1610;
 				LastUpgradeCheck = 1610;
 				TargetAttributes = {
+					0F3D1595293D70FE62E1D699 = {
+						CreatedOnToolsVersion = 16.1;
+					};
 					44A4C3022E271D570011A613 = {
 						CreatedOnToolsVersion = 16.1;
 						LastSwiftMigration = 1610;
@@ -320,6 +364,7 @@
 				44B59A972DE9042100A05B89 /* SparklingGoTests */,
 				44B59AA12DE9042100A05B89 /* SparklingGoUITests */,
 				44A4C3022E271D570011A613 /* SparklingMethodTests */,
+				0F3D1595293D70FE62E1D699 /* SparklingGoInHouse */,
 			);
 		};
 /* End PBXProject section */
@@ -351,6 +396,14 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F9F42152B9FB6FA0002CB348 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DF4098C8CC6BF6DB06FE60D9 /* LynxResources in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -447,6 +500,23 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-SparklingMethodTests/Pods-SparklingMethodTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		3EAEEF4A78968ADA92CAEA6D /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-SparklingGoInHouse/Pods-SparklingGoInHouse-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-SparklingGoInHouse/Pods-SparklingGoInHouse-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-SparklingGoInHouse/Pods-SparklingGoInHouse-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		51F49D3A4032A6DD15914B92 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -503,6 +573,23 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		8811720C0D66DA4CF5F429BA /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-SparklingGoInHouse/Pods-SparklingGoInHouse-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-SparklingGoInHouse/Pods-SparklingGoInHouse-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-SparklingGoInHouse/Pods-SparklingGoInHouse-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		912D5F4C591FEE53AE2B078A /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -547,6 +634,28 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		BFDC12B261721A1C9F145346 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-SparklingGoInHouse-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		D8B9D87ED24102E5E029ED28 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -584,6 +693,13 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		30FBC3F8EE5A026AC9B722C8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		44A4C2FF2E271D570011A613 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -981,6 +1097,92 @@
 			};
 			name = Release;
 		};
+		498C6BF26BC533A767F11410 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = F37D60B7A70AAC4EB75DD22C /* Pods-SparklingGoInHouse.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "Sparkling Playground";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "This app needs access to the photo library to save downloaded images.";
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 14.6;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sparkling.playground;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/SparklingGo/SparklingGo/Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+				XROS_DEPLOYMENT_TARGET = 2.1;
+			};
+			name = Debug;
+		};
+		F89CA2A5F532515237E9CBAD /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9DAB5FA9ECA8B400DB3F300A /* Pods-SparklingGoInHouse.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "Sparkling Playground";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "This app needs access to the photo library to save downloaded images.";
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 14.6;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sparkling.playground;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/SparklingGo/SparklingGo/Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+				XROS_DEPLOYMENT_TARGET = 2.1;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1025,6 +1227,15 @@
 			buildConfigurations = (
 				44B59AB32DE9042100A05B89 /* Debug */,
 				44B59AB42DE9042100A05B89 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8B74036F7C466DCA6D698700 /* Build configuration list for PBXNativeTarget "SparklingGoInHouse" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				498C6BF26BC533A767F11410 /* Debug */,
+				F89CA2A5F532515237E9CBAD /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/packages/playground/ios/SparklingGo.xcodeproj/xcshareddata/xcschemes/SparklingGoInHouse.xcscheme
+++ b/packages/playground/ios/SparklingGo.xcodeproj/xcshareddata/xcschemes/SparklingGoInHouse.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0F3D1595293D70FE62E1D699"
+               BuildableName = "SparklingGoInHouse.app"
+               BlueprintName = "SparklingGoInHouse"
+               ReferencedContainer = "container:SparklingGo.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0F3D1595293D70FE62E1D699"
+            BuildableName = "SparklingGoInHouse.app"
+            BlueprintName = "SparklingGoInHouse"
+            ReferencedContainer = "container:SparklingGo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0F3D1595293D70FE62E1D699"
+            BuildableName = "SparklingGoInHouse.app"
+            BlueprintName = "SparklingGoInHouse"
+            ReferencedContainer = "container:SparklingGo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/packages/playground/ios/SparklingGo/SparklingGo/SparklingGoApp.swift
+++ b/packages/playground/ios/SparklingGo/SparklingGo/SparklingGoApp.swift
@@ -9,6 +9,9 @@ import SDWebImage
 import SDWebImageWebPCoder
 import SparklingMethod
 import SparklingMacro
+#if canImport(Sparkling_DebugTool)
+import Sparkling_DebugTool
+#endif
 
 class AppDelegate: NSObject, UIApplicationDelegate {
     var window: UIWindow?
@@ -17,7 +20,9 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         window = UIWindow(frame: UIScreen.main.bounds)
         let webPCoder = SDImageWebPCoder.shared
         SDImageCodersManager.shared.addCoder(webPCoder)
-        
+        #if canImport(Sparkling_DebugTool)
+        SparklingDebugTool.setup()
+        #endif
         SPKServiceRegister.registerAll()
         SPKExecuteAllPrepareBootTask()
         SPKKit.DIContainer.register(SPKTrackerService.self, scope: ServiceScope.transient) {

--- a/packages/sparkling-app-cli/src/commands/run-ios.ts
+++ b/packages/sparkling-app-cli/src/commands/run-ios.ts
@@ -70,6 +70,24 @@ function resolveWorkspacePath(cwd: string): string | null {
   return candidates.find(p => fs.existsSync(p)) ?? null;
 }
 
+/**
+ * Pick the scheme to build. Prefer `SparklingGoInHouse` when present: it is
+ * the developer-facing target that links Sparkling-DebugTool / DebugRouter so
+ * LynxDevTool can attach. Older projects only have `SparklingGo`, so fall
+ * back to that for backwards compatibility.
+ */
+function resolveScheme(cwd: string): string {
+  const inHouseScheme = path.resolve(
+    cwd,
+    'ios',
+    'SparklingGo.xcodeproj',
+    'xcshareddata',
+    'xcschemes',
+    'SparklingGoInHouse.xcscheme',
+  );
+  return fs.existsSync(inHouseScheme) ? 'SparklingGoInHouse' : 'SparklingGo';
+}
+
 function findNearestGemfile(startDir: string): string | null {
   let current = startDir;
   const { root } = path.parse(startDir);
@@ -378,14 +396,18 @@ export async function runIos(options: RunIosOptions): Promise<void> {
   }
 
   // ── Step 2: Build (always runs, regardless of simulator state) ──
+  const scheme = resolveScheme(options.cwd);
+  if (isVerboseEnabled()) {
+    verboseLog(`Selected scheme: ${scheme}`);
+  }
   const destination = `id=${device.udid}`;
   const derivedDataPath = path.resolve(options.cwd, 'ios/build');
-  console.log(ui.info('Building Xcode project (this may take a while)...'));
+  console.log(ui.info(`Building Xcode project with scheme \`${scheme}\` (this may take a while)...`));
   await runCommand('xcodebuild', [
     '-workspace',
     workspacePath,
     '-scheme',
-    'SparklingGo',
+    scheme,
     '-configuration',
     'Debug',
     '-sdk',
@@ -402,7 +424,7 @@ export async function runIos(options: RunIosOptions): Promise<void> {
   ], { cwd: options.cwd });
 
   // ── Step 3: Install & launch (best-effort, only if simulator is up) ──
-  const appPath = path.resolve(options.cwd, 'ios/build/Build/Products/Debug-iphonesimulator/SparklingGo.app');
+  const appPath = path.resolve(options.cwd, `ios/build/Build/Products/Debug-iphonesimulator/${scheme}.app`);
   if (!fs.existsSync(appPath)) {
     console.warn(ui.warn(`Built app not found at ${appPath}, skipped simulator install/launch.`));
   } else if (!simulatorReady) {

--- a/template/sparkling-app-template/ios/Podfile
+++ b/template/sparkling-app-template/ios/Podfile
@@ -25,6 +25,8 @@ def sparkling_devtool
   # BEGIN SPARKLING AUTOLINK
   pod 'Sparkling-DebugTool', '2.1.0-rc.12'
   # END SPARKLING AUTOLINK
+  pod 'DebugRouter', '5.0.15'
+  pod 'DebugRouter/MessageTransceiverEnable', '5.0.15'
 end
 
 def sparkling_kit
@@ -32,13 +34,12 @@ def sparkling_kit
   pod 'SparklingMacro', '2.1.0-rc.12'
   sparkling_methods
   sparkling_methods_dep
-  sparkling_devtool
 
   pod 'Lynx', '3.6.0', :subspecs => [
     'Framework',
     'ReleaseResource'
   ]
-  
+
   pod 'PrimJS', '3.6.1', :subspecs => ['quickjs', 'napi']
 
   pod 'LynxService', '3.6.0', :subspecs => [
@@ -46,17 +47,27 @@ def sparkling_kit
     'Log',
     'Http',
   ]
-  
+
   pod 'SnapKit'
   pod 'Mantle', '~> 2.2.0'
-  
+
   pod 'SDWebImage','5.15.5'
   pod 'SDWebImageWebPCoder', '0.11.0'
 end
 
 use_frameworks!
+
+# SparklingGo is the production-style target: no devtool dependencies are
+# linked, so DebugRouter / LynxDevtool symbols cannot leak into a Release
+# build. Use SparklingGoInHouse for day-to-day development (it is what
+# `pnpm run:ios` builds).
 target 'SparklingGo' do
   sparkling_kit
+end
+
+target 'SparklingGoInHouse' do
+  sparkling_kit
+  sparkling_devtool
 end
 
 target 'SparklingGoTests' do
@@ -69,32 +80,4 @@ end
 
 target 'SparklingGoUITests' do
   sparkling_kit
-end
-
-# Strip devtool pods from Release builds so they are debug-only.
-devtool_frameworks = ['Sparkling_DebugTool']
-devtool_pod_names = ['Sparkling-DebugTool']
-
-post_install do |installer|
-  # 1. Exclude all source files from devtool pod targets in Release
-  installer.target_installation_results.pod_target_installation_results.each do |pod_name, result|
-    next unless devtool_pod_names.any? { |n| pod_name.to_s.include?(n) }
-    result.native_target.build_configurations.each do |config|
-      if config.name == 'Release'
-        config.build_settings['EXCLUDED_SOURCE_FILE_NAMES'] = '*'
-      end
-    end
-  end
-
-  # 2. Strip devtool framework references from app target linker flags in Release
-  installer.aggregate_targets.each do |aggregate_target|
-    aggregate_target.xcconfigs.each do |config_name, xcconfig|
-      next unless config_name == 'Release'
-      devtool_frameworks.each do |fw|
-        xcconfig.other_linker_flags[:frameworks].delete(fw)
-      end
-      xcconfig_path = aggregate_target.xcconfig_path(config_name)
-      xcconfig.save_as(xcconfig_path)
-    end
-  end
 end

--- a/template/sparkling-app-template/ios/SparklingGo.xcodeproj/project.pbxproj
+++ b/template/sparkling-app-template/ios/SparklingGo.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		07B2FB684B8D385782138000 /* Pods_SparklingGoUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AD74935FFBD17E3B3D4E69A /* Pods_SparklingGoUITests.framework */; };
 		903208242ED9629900167236 /* LynxResources in Resources */ = {isa = PBXBuildFile; fileRef = 903208232ED9629900167236 /* LynxResources */; };
+		9CF6B09A1F033C4D476754DE /* LynxResources in Resources */ = {isa = PBXBuildFile; fileRef = 903208232ED9629900167236 /* LynxResources */; };
 		CEAB8C5202B26CF8F0BE5581 /* Pods_SparklingGo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B00F0DF4C89E15C31BC93A3 /* Pods_SparklingGo.framework */; };
 		DE44680A8011EA315778F328 /* Pods_SparklingMethodTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80857B85C0422883390B2606 /* Pods_SparklingMethodTests.framework */; };
 		E1EA18997313C777BCB28C73 /* Pods_SparklingGoTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 34294AA1E3153C7FF24DA29D /* Pods_SparklingGoTests.framework */; };
@@ -53,6 +54,7 @@
 		9AD74935FFBD17E3B3D4E69A /* Pods_SparklingGoUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SparklingGoUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B5E42D779278857A5AAB06BF /* Pods-SparklingGoUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SparklingGoUITests.debug.xcconfig"; path = "Target Support Files/Pods-SparklingGoUITests/Pods-SparklingGoUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		BEB0A8939FDC0E69DE1ACBE1 /* Pods-SparklingGoUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SparklingGoUITests.release.xcconfig"; path = "Target Support Files/Pods-SparklingGoUITests/Pods-SparklingGoUITests.release.xcconfig"; sourceTree = "<group>"; };
+		C070511DD16ADB8A7E080D02 /* SparklingGoInHouse.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SparklingGoInHouse.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C50586CC4ECBC63F4329F466 /* Pods-SparklingMethodTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SparklingMethodTests.release.xcconfig"; path = "Target Support Files/Pods-SparklingMethodTests/Pods-SparklingMethodTests.release.xcconfig"; sourceTree = "<group>"; };
 		E28DB50001F3EFBF06162E18 /* Pods-SparklingGo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SparklingGo.debug.xcconfig"; path = "Target Support Files/Pods-SparklingGo/Pods-SparklingGo.debug.xcconfig"; sourceTree = "<group>"; };
 		FC9A690424F49FA47736FA61 /* Pods-SparklingGoTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SparklingGoTests.release.xcconfig"; path = "Target Support Files/Pods-SparklingGoTests/Pods-SparklingGoTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -122,6 +124,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		AE22B03FC3758922AAC2EDE7 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -157,6 +166,7 @@
 				44B59A982DE9042100A05B89 /* SparklingGoTests.xctest */,
 				44B59AA22DE9042100A05B89 /* SparklingGoUITests.xctest */,
 				44A4C3032E271D570011A613 /* SparklingMethodTests.xctest */,
+				C070511DD16ADB8A7E080D02 /* SparklingGoInHouse.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -275,6 +285,26 @@
 			productReference = 44B59AA22DE9042100A05B89 /* SparklingGoUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
+		CC2835169C57443FEF969D50 /* SparklingGoInHouse */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3BD2CED64D45F66E4B041308 /* Build configuration list for PBXNativeTarget "SparklingGoInHouse" */;
+			buildPhases = (
+				BFC146A4025F02FD285C00CD /* Sources */,
+				AE22B03FC3758922AAC2EDE7 /* Frameworks */,
+				EF4438325BA9DBA2ADD21037 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				44B59A892DE9041F00A05B89 /* SparklingGo */,
+			);
+			name = SparklingGoInHouse;
+			productName = SparklingGoInHouse;
+			productReference = C070511DD16ADB8A7E080D02 /* SparklingGoInHouse.app */;
+			productType = "com.apple.product-type.application";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -300,6 +330,9 @@
 						CreatedOnToolsVersion = 16.1;
 						TestTargetID = 44B59A862DE9041F00A05B89;
 					};
+					CC2835169C57443FEF969D50 = {
+						CreatedOnToolsVersion = 16.1;
+					};
 				};
 			};
 			buildConfigurationList = 44B59A822DE9041F00A05B89 /* Build configuration list for PBXProject "SparklingGo" */;
@@ -319,6 +352,7 @@
 				44B59A972DE9042100A05B89 /* SparklingGoTests */,
 				44B59AA12DE9042100A05B89 /* SparklingGoUITests */,
 				44A4C3022E271D570011A613 /* SparklingMethodTests */,
+				CC2835169C57443FEF969D50 /* SparklingGoInHouse */,
 			);
 		};
 /* End PBXProject section */
@@ -350,6 +384,14 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EF4438325BA9DBA2ADD21037 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9CF6B09A1F033C4D476754DE /* LynxResources in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -611,6 +653,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		BFC146A4025F02FD285C00CD /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -807,7 +856,7 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = "Info.plist";
+				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Sparkling Template";
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "This app needs access to the photo library to save downloaded images.";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
@@ -850,7 +899,7 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = "Info.plist";
+				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Sparkling Template";
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "This app needs access to the photo library to save downloaded images.";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
@@ -980,9 +1029,102 @@
 			};
 			name = Release;
 		};
+		CB11BD834D252FE605390701 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = RL87M95CBB;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "Sparkling Template";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "This app needs access to the photo library to save downloaded images.";
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 14.6;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sparkling.app.SparklingGo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/SparklingGo/SparklingGo/Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+				XROS_DEPLOYMENT_TARGET = 2.1;
+			};
+			name = Debug;
+		};
+		E3C23746D32E724CECA7BC3E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = RL87M95CBB;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "Sparkling Template";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "This app needs access to the photo library to save downloaded images.";
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 14.6;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sparkling.app.SparklingGo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/SparklingGo/SparklingGo/Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+				XROS_DEPLOYMENT_TARGET = 2.1;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		3BD2CED64D45F66E4B041308 /* Build configuration list for PBXNativeTarget "SparklingGoInHouse" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CB11BD834D252FE605390701 /* Debug */,
+				E3C23746D32E724CECA7BC3E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		44A4C30B2E271D570011A613 /* Build configuration list for PBXNativeTarget "SparklingMethodTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/template/sparkling-app-template/ios/SparklingGo.xcodeproj/xcshareddata/xcschemes/SparklingGoInHouse.xcscheme
+++ b/template/sparkling-app-template/ios/SparklingGo.xcodeproj/xcshareddata/xcschemes/SparklingGoInHouse.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CC2835169C57443FEF969D50"
+               BuildableName = "SparklingGoInHouse.app"
+               BlueprintName = "SparklingGoInHouse"
+               ReferencedContainer = "container:SparklingGo.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CC2835169C57443FEF969D50"
+            BuildableName = "SparklingGoInHouse.app"
+            BlueprintName = "SparklingGoInHouse"
+            ReferencedContainer = "container:SparklingGo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CC2835169C57443FEF969D50"
+            BuildableName = "SparklingGoInHouse.app"
+            BlueprintName = "SparklingGoInHouse"
+            ReferencedContainer = "container:SparklingGo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/template/sparkling-app-template/ios/SparklingGo/SparklingGo/DebugDevURLSupport.swift
+++ b/template/sparkling-app-template/ios/SparklingGo/SparklingGo/DebugDevURLSupport.swift
@@ -5,8 +5,8 @@
 import Foundation
 import Sparkling
 import UIKit
-#if canImport(DebugTool)
-import DebugTool
+#if canImport(Sparkling_DebugTool)
+import Sparkling_DebugTool
 #endif
 
 enum DebugDevURLSupport {
@@ -69,7 +69,7 @@ enum DebugDevURLSupport {
     }
 
     static func storedDevURL(fallback: String) -> String {
-        #if canImport(DebugTool)
+        #if canImport(Sparkling_DebugTool)
         SparklingDebugTool.devURL(fallback: fallback)
         #else
         fallback
@@ -77,13 +77,13 @@ enum DebugDevURLSupport {
     }
 
     static func saveDevURL(_ url: String) {
-        #if canImport(DebugTool)
+        #if canImport(Sparkling_DebugTool)
         SparklingDebugTool.setDevURL(url)
         #endif
     }
 
     static func showDevURLDialog(from controller: UIViewController, initialURL: String?, onSaved: @escaping (String) -> Void) {
-        #if canImport(DebugTool)
+        #if canImport(Sparkling_DebugTool)
         SparklingDebugTool.showDevURLDialog(from: controller, initialURL: initialURL, onSaved: onSaved)
         #else
         onSaved(initialURL ?? fallbackDevURL())

--- a/template/sparkling-app-template/ios/SparklingGo/SparklingGo/SparklingGoApp.swift
+++ b/template/sparkling-app-template/ios/SparklingGo/SparklingGo/SparklingGoApp.swift
@@ -9,6 +9,9 @@ import SDWebImage
 import SDWebImageWebPCoder
 import SparklingMethod
 import SparklingMacro
+#if canImport(Sparkling_DebugTool)
+import Sparkling_DebugTool
+#endif
 
 class AppDelegate: NSObject, UIApplicationDelegate {
     var window: UIWindow?
@@ -17,7 +20,9 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         window = UIWindow(frame: UIScreen.main.bounds)
         let webPCoder = SDImageWebPCoder.shared
         SDImageCodersManager.shared.addCoder(webPCoder)
-        
+        #if canImport(Sparkling_DebugTool)
+        SparklingDebugTool.setup()
+        #endif
         SPKServiceRegister.registerAll()
         SPKExecuteAllPrepareBootTask()
         SPKKit.DIContainer.register(SPKTrackerService.self, scope: ServiceScope.transient) {


### PR DESCRIPTION
## Summary

`LynxDevTool` discovers running Lynx apps by listening for `DebugRouter` sessions. When
`DebugRouter.enableAllSessions()` is never called, the tool sees nothing. The root cause was that
`SparklingDebugTool.setup()` (which calls `enableAllSessions()`) was never invoked —
`Sparkling-DebugTool` was linked to the single `SparklingGo` target via a `post_install`
linker-flag trick that silently broke in recent Xcode/CocoaPods versions, so the
`#if canImport(Sparkling_DebugTool)` guards were always false at compile time.

This PR fixes the issue by splitting the Xcode target into two:

- **`SparklingGo`** — production target, no devtool symbols linked
- **`SparklingGoInHouse`** — developer/daily-driver target, `Sparkling-DebugTool` + `DebugRouter` linked

`pnpm run:ios` now automatically builds `SparklingGoInHouse` when its scheme file is present,
so LynxDevTool can attach out of the box.

## Related issues

Fixes #88

## Changes

- **`ios/Podfile`** (playground + template): extract `sparkling_devtool` helper
  (`Sparkling-DebugTool`, `DebugRouter`, `DebugRouter/MessageTransceiverEnable`) into its own
  block; add `SparklingGoInHouse` target that includes both `sparkling_kit` and
  `sparkling_devtool`; remove the old `post_install` linker-flag stripping hack
- **`SparklingGoApp.swift`** (playground + template): add `#if canImport(Sparkling_DebugTool)`
  guard around `SparklingDebugTool.setup()` — now actually executes in the
  `SparklingGoInHouse` build
- **`DebugDevURLSupport.swift`** (template): fix dormant bug where `#if canImport(DebugTool)`
  (wrong module name, always false) was used instead of `#if canImport(Sparkling_DebugTool)`,
  making dev-URL persistence and the URL-edit dialog dead code
- **`project.pbxproj`** (playground + template): add `SparklingGoInHouse` `PBXNativeTarget`
  sharing the same `PBXFileSystemSynchronizedRootGroup` as `SparklingGo`
- **`SparklingGoInHouse.xcscheme`** (playground + template): new shared scheme for the
  in-house target
- **`run-ios.ts`**: add `resolveScheme()` helper that picks `SparklingGoInHouse` when its
  `.xcscheme` is present, falling back to `SparklingGo`; wire the resolved scheme through
  xcodebuild and the installed-app path lookup

## How to test

```bash
# From repo root
pnpm install
pnpm run:ios   # inside a Sparkling app directory (playground or a scaffolded demo)
```

1. Wait for the dev server to start and the app to launch on the simulator.
2. Open LynxDevTool → the running Sparkling app should now appear in the device list.
3. Confirm SparklingGoInHouse is the scheme being built (visible in xcodebuild output).
4. Verify production builds still use SparklingGo — DebugRouter should not appear in otool -L output of the release .app.

## Checklist
- [x] I read `CONTRIBUTING.md`.
- [x] I linked a related issue (or explained why this is standalone).
- [x] I ran relevant checks
- [x] I updated docs/examples (if needed).
- [x] I added/updated tests (if applicable), or explained why not.
