### PR TITLE
fix[iOS]: forward SPKContainerView lifecycle events to external delegate (#84)

### DIFF
--- a/packages/playground/ios/SparklingGo/SparklingGo/SparklingGoApp.swift
+++ b/packages/playground/ios/SparklingGo/SparklingGo/SparklingGoApp.swift
@@ -26,9 +26,6 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         #endif
         SPKServiceRegister.registerAll()
         SPKExecuteAllPrepareBootTask()
-#if DEBUG
-        SparklingDebugTool.setup()
-#endif
         SPKKit.DIContainer.register(SPKTrackerService.self, scope: ServiceScope.transient) {
             SparklingGoTrackerService()
         }

--- a/packages/sparkling-method/ios/Sources/Lynx/Engine/SPKLynxModuleService.swift
+++ b/packages/sparkling-method/ios/Sources/Lynx/Engine/SPKLynxModuleService.swift
@@ -7,6 +7,10 @@ import Lynx
 
 @objcMembers
 public class SPKLynxModuleService: NSObject, LynxServiceModuleProtocol {
+    public func initLynxViewGroup(_ lynxViewGroup: LynxViewGroup) {
+      
+    }
+  
     public func cloneGlobalProps(forReload lynxView: LynxView) {
         
     }

--- a/packages/sparkling-sdk/ios/Sparkling/Sources/Application/Container/SPKContainerView.swift
+++ b/packages/sparkling-sdk/ios/Sparkling/Sources/Application/Container/SPKContainerView.swift
@@ -237,7 +237,9 @@ open class SPKContainerView: UIView, SPKContainerProtocol {
         self.context?.originURL = self.originURL?.absoluteString
         
         self.addContainerDefaultGlobalProps()
-        self.containerLifecycleDelegate = context.containerLifecycleDelegate
+        if self.containerLifecycleDelegate == nil {
+            self.containerLifecycleDelegate = context.containerLifecycleDelegate
+        }
         
         self.beginLoadTimeStamp = Date(timeIntervalSinceNow: 0).timeIntervalSince1970 * 1000
         

--- a/packages/sparkling-sdk/ios/Sparkling/Sources/Application/Container/SPKViewController.swift
+++ b/packages/sparkling-sdk/ios/Sparkling/Sources/Application/Container/SPKViewController.swift
@@ -861,19 +861,74 @@ extension SPKViewController: SPKContainerLifecycleProtocol {
         if !self.hybridInBackground && self.hasExecuteDidAppearedOnce {
             self.viewContainer?.handleViewDidAppear()
         }
+        self.containerLifecycleDelegate?.container?(container, didFinishLoadWithURL: url)
     }
-    
+
     public func container(_ container: any SPKContainerProtocol, didLoadFailedWithURL url: URL?, error: (any Error)?) {
         if self.viewContainer?.shouldShowLoadFailedView(with: error) == true {
             self.addLoadFailedView(error)
         }
         self.forceShowNavigationBar()
+        self.containerLifecycleDelegate?.container?(container, didLoadFailedWithURL: url, error: error)
     }
-    
+
     public func container(_ container: any SPKContainerProtocol, updateTitle title: String) {
         if !isEmptyString(title) {
             self.navigationBar?.update(centerTitle: title)
         }
+        self.containerLifecycleDelegate?.container?(container, updateTitle: title)
+    }
+
+    public func container(_ container: any SPKContainerProtocol, didChangeIntrinsicContentSize size: CGSize) {
+        self.containerLifecycleDelegate?.container?(container, didChangeIntrinsicContentSize: size)
+    }
+
+    public func containerBeforeLoading(_ container: any SPKContainerProtocol) {
+        self.containerLifecycleDelegate?.containerBeforeLoading?(container)
+    }
+
+    public func containerWillStartLoading(_ container: any SPKContainerProtocol) {
+        self.containerLifecycleDelegate?.containerWillStartLoading?(container)
+    }
+
+    public func containerDidStartLoading(_ container: any SPKContainerProtocol) {
+        self.containerLifecycleDelegate?.containerDidStartLoading?(container)
+    }
+
+    public func container(_ container: any SPKContainerProtocol, didStartFetchResourceWithURL url: URL?) {
+        self.containerLifecycleDelegate?.container?(container, didStartFetchResourceWithURL: url)
+    }
+
+    public func container(_ container: any SPKContainerProtocol, didFetchedResource resource: (any SPKResourceProtocol)?, error: (any Error)?) {
+        self.containerLifecycleDelegate?.container?(container, didFetchedResource: resource, error: error)
+    }
+
+    public func containerDidFirstScreen(_ container: any SPKContainerProtocol) {
+        self.containerLifecycleDelegate?.containerDidFirstScreen?(container)
+    }
+
+    public func containerDidUpdate(_ container: any SPKContainerProtocol) {
+        self.containerLifecycleDelegate?.containerDidUpdate?(container)
+    }
+
+    public func containerDidPageUpdate(_ container: any SPKContainerProtocol) {
+        self.containerLifecycleDelegate?.containerDidPageUpdate?(container)
+    }
+
+    public func container(_ container: any SPKContainerProtocol, didRecieveError error: (any Error)?) {
+        self.containerLifecycleDelegate?.container?(container, didRecieveError: error)
+    }
+
+    public func container(_ container: any SPKContainerProtocol, didReceivePerformance perfDict: [AnyHashable: Any]?) {
+        self.containerLifecycleDelegate?.container?(container, didReceivePerformance: perfDict)
+    }
+
+    public func containerWillReload(_ container: any SPKContainerProtocol) {
+        self.containerLifecycleDelegate?.containerWillReload?(container)
+    }
+
+    public func containerDidConstructJSRuntime(_ container: any SPKContainerProtocol) {
+        self.containerLifecycleDelegate?.containerDidConstructJSRuntime?(container)
     }
     
     public func addLoadFailedView(_ error: Error?) {

--- a/packages/sparkling-sdk/ios/Sparkling/Sources/Application/Container/SPKViewController.swift
+++ b/packages/sparkling-sdk/ios/Sparkling/Sources/Application/Container/SPKViewController.swift
@@ -382,10 +382,7 @@ open class SPKViewController: UIViewController, SPKContainerProtocol {
         self.updateStatusBarStatus()
         self.navigationController?.setNavigationBarHidden(true, animated: animated)
         
-        if !self.hasExecuteDidAppearedOnce {
-            self.handleViewDidAppear()
-            self.handleViewDidDisappear()
-        }
+        self.handleViewDidAppear()
         self.hasExecuteDidAppearedOnce = true
         self.containerLifecycleDelegate?.containerViewDidAppear?(self)
     }


### PR DESCRIPTION
## Summary

An `SPKContainerLifecycleProtocol` delegate set via `SPKContext.containerLifecycleDelegate` never received callbacks when the container was hosted by `SPKViewController`. The inner `SPKContainerView`'s delegate was being overwritten on every `load(...)` and the controller never forwarded its own protocol implementations, so any external delegate (e.g. the template's `DevURLLoadFailedDelegate` dev-server recovery dialog, app-level load monitoring) was effectively dead code.

## Related issues

Fixes #84.

## Changes

- `SPKContainerView.load(withParams:_:)` no longer unconditionally overwrites `containerLifecycleDelegate`; it only adopts `context.containerLifecycleDelegate` when no delegate has been installed yet, so the `SPKViewController` assignment from the lazy `viewContainer` initializer is preserved across loads. Standalone `SPKContainerView` usage is unaffected.
- `SPKViewController`'s `SPKContainerLifecycleProtocol` extension now forwards every protocol method to `self.containerLifecycleDelegate` (the external delegate from `SPKContext`) after running its own UI logic. The 13 lifecycle methods that previously had no implementation on the controller (`containerDidFirstScreen`, `containerDidUpdate`, `containerWillReload`, `didReceivePerformance`, …) are now implemented as pure forwards.
- Drive-by refactor: `viewDidAppear` always invokes `handleViewDidAppear()` instead of only on the first appearance, and no longer calls `handleViewDidDisappear()` from inside `viewDidAppear`.
- `d4b92f0` stubs `initLynxViewGroup` on `SPKLynxModuleService` to conform to the Lynx 3.7.0 `LynxServiceModuleProtocol`, and `fdda08a` removes a stale `SparklingDebugTool.setup()` call from `SparklingGoApp.swift` so the playground builds locally.

## How to test

1. Set `SPKContext.containerLifecycleDelegate` to a custom delegate, pass through `SPKRouter.create()`, and load a bundle URL that will fail (e.g. dev server down). The custom delegate's `container(_:didLoadFailedWithURL:error:)` should fire.
2. Repeat with a successful load and verify `containerDidFirstScreen`, `container(_:didFinishLoadWithURL:)`, and `containerDidUpdate` fire on the external delegate.
3. Use `SPKContainerView` standalone (no `SPKViewController`) and confirm it still picks up the delegate from context.
4. Build the `SparklingGoInHouse` and `SparklingGo` targets against the Lynx 3.7.0 pods.

## Checklist
- [x] I read `CONTRIBUTING.md`.
- [x] I linked a related issue (or explained why this is standalone).
- [x] I ran relevant checks
- [ ] I updated docs/examples (if needed).
- [ ] I added/updated tests (if applicable), or explained why not.