### PR TITLE
fix(types): restore sparklingVersion in GlobalProps type

### DIFF
--- a/packages/sparkling-types/src/index.ts
+++ b/packages/sparkling-types/src/index.ts
@@ -173,8 +173,11 @@ declare module '@lynx-js/types' {
     /** Timestamp (as string) when the container was initialized. */
     containerInitTime: string;
 
-    /** Version of the underlying Lynx SDK. */
+    /** Version of the underlying Lynx SDK (e.g. `"3.6.0"`). */
     lynxSdkVersion: string;
+
+    /** Version of the Sparkling SDK (e.g. `"1.0.0"`). */
+    sparklingVersion: string;
 
     /**
      * Template resource data passed to the container.


### PR DESCRIPTION
## Summary

Re-adds `sparklingVersion: string` to the `GlobalProps` TypeScript type in `packages/sparkling-types`.

The field is set at runtime by both native SDKs and returns `"1.0.0"`:

- **iOS** — `packages/sparkling-sdk/ios/Sparkling/Sources/Service/LynxService/SPKLynxKitUtils.swift`:
  ```swift
  globalPropos.updateValue(SPKVersion.SPKVersion(), forKey: \"sparklingVersion\")
  ```
- **Android** — `RuntimeInfo.SPARKLING_VERSION` / `SPARKLING_VERSION_VALUE = \"1.0.0\"`, wired through `GlobalPropsUtils.builtInStableFields`

It was originally added to the TS type in #65 but inadvertently removed by ad2b4a8 (\"fix(sdk): exclude iOS macro dirs and sync globalProps typing\"), leaving the type definition out of sync with what the SDKs actually emit. This change closes that gap.

Also restores the example value (`\"3.6.0\"`) in the `lynxSdkVersion` doc comment that was dropped in the same commit, for consistency with the new `sparklingVersion` doc.

This obsoletes #55, which was already closed because the rest of its commits had been integrated through other PRs.

## Test plan

- [ ] `pnpm -w build` / type-check passes
- [ ] In a consumer Lynx page, `lynx.__globalProps.sparklingVersion` is typed as `string` (no `any`) and returns `\"1.0.0\"` on iOS
- [ ] Same check on Android
- [ ] `lynx.__globalProps.lynxSdkVersion` still returns the Lynx engine version (no regression)