### PR TITLE
fix:  fix release template verification

### DIFF
--- a/.github/actions/preflight-registry-auth/action.yml
+++ b/.github/actions/preflight-registry-auth/action.yml
@@ -72,10 +72,16 @@ runs:
         fi
 
         BEARER_TOKEN=$(printf '%s:%s' "$MAVEN_CENTRAL_USERNAME" "$MAVEN_CENTRAL_PASSWORD" | base64 | tr -d '\n')
+        echo "::add-mask::$BEARER_TOKEN"
+        CURL_CONFIG=$(mktemp)
+        trap 'rm -f "$CURL_CONFIG"' EXIT
+        chmod 600 "$CURL_CONFIG"
+        printf 'header = "Authorization: Bearer %s"\n' "$BEARER_TOKEN" > "$CURL_CONFIG"
+
         HTTP_CODE=""
         for attempt in 1 2 3; do
           HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
-            -H "Authorization: Bearer ${BEARER_TOKEN}" \
+            --config "$CURL_CONFIG" \
             "https://ossrh-staging-api.central.sonatype.com/manual/search/repositories?ip=any&profile_id=com.tiktok.sparkling")
           if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
             echo "✅ Maven Central auth looks valid"

--- a/.github/actions/preflight-registry-auth/action.yml
+++ b/.github/actions/preflight-registry-auth/action.yml
@@ -60,6 +60,18 @@ runs:
         SIGNING_PASSWORD: ${{ inputs.signing_password }}
         SIGNING_KEY: ${{ inputs.signing_key }}
       run: |
+        mask_github_value() {
+          local value="$1"
+          value="${value//'%'/'%25'}"
+          value="${value//$'\r'/'%0D'}"
+          value="${value//$'\n'/'%0A'}"
+          echo "::add-mask::$value"
+        }
+
+        set +x
+        [ -n "${MAVEN_CENTRAL_USERNAME:-}" ] && mask_github_value "$MAVEN_CENTRAL_USERNAME"
+        [ -n "${MAVEN_CENTRAL_PASSWORD:-}" ] && mask_github_value "$MAVEN_CENTRAL_PASSWORD"
+
         MISSING=""
         [ -z "$MAVEN_CENTRAL_USERNAME" ] && MISSING="$MISSING MAVEN_CENTRAL_USERNAME"
         [ -z "$MAVEN_CENTRAL_PASSWORD" ] && MISSING="$MISSING MAVEN_CENTRAL_PASSWORD"
@@ -71,9 +83,8 @@ runs:
           exit 1
         fi
 
-        set +x
         BEARER_TOKEN=$(printf '%s:%s' "$MAVEN_CENTRAL_USERNAME" "$MAVEN_CENTRAL_PASSWORD" | base64 | tr -d '\n')
-        echo "::add-mask::$BEARER_TOKEN"
+        mask_github_value "$BEARER_TOKEN"
         CURL_CONFIG=$(mktemp)
         trap 'rm -f "$CURL_CONFIG"' EXIT
         chmod 600 "$CURL_CONFIG"

--- a/.github/actions/preflight-registry-auth/action.yml
+++ b/.github/actions/preflight-registry-auth/action.yml
@@ -71,15 +71,31 @@ runs:
           exit 1
         fi
 
-        BEARER_TOKEN=$(printf '%s:%s' "$MAVEN_CENTRAL_USERNAME" "$MAVEN_CENTRAL_PASSWORD" | base64)
-        HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
-          -H "Authorization: Bearer ${BEARER_TOKEN}" \
-          "https://ossrh-staging-api.central.sonatype.com/manual/search/repositories?ip=any&profile_id=com.tiktok.sparkling")
-        if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
-          echo "::error::Maven Central API auth check failed (HTTP $HTTP_CODE)."
-          exit 1
-        fi
-        echo "✅ Maven Central auth looks valid"
+        BEARER_TOKEN=$(printf '%s:%s' "$MAVEN_CENTRAL_USERNAME" "$MAVEN_CENTRAL_PASSWORD" | base64 | tr -d '\n')
+        HTTP_CODE=""
+        for attempt in 1 2 3; do
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "Authorization: Bearer ${BEARER_TOKEN}" \
+            "https://ossrh-staging-api.central.sonatype.com/manual/search/repositories?ip=any&profile_id=com.tiktok.sparkling")
+          if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
+            echo "✅ Maven Central auth looks valid"
+            exit 0
+          fi
+          echo "::warning::Maven Central API preflight attempt ${attempt}/3 returned HTTP ${HTTP_CODE}."
+          if [ "$attempt" != "3" ]; then
+            sleep 20
+          fi
+        done
+
+        case "$HTTP_CODE" in
+          403|429|5*)
+            echo "::warning::Maven Central API preflight is inconclusive (HTTP ${HTTP_CODE}); continuing so the publish step can validate credentials directly."
+            ;;
+          *)
+            echo "::error::Maven Central API auth check failed (HTTP ${HTTP_CODE})."
+            exit 1
+            ;;
+        esac
 
     - name: Setup Ruby
       if: ${{ inputs.publish_ios == 'true' }}

--- a/.github/actions/preflight-registry-auth/action.yml
+++ b/.github/actions/preflight-registry-auth/action.yml
@@ -71,6 +71,7 @@ runs:
           exit 1
         fi
 
+        set +x
         BEARER_TOKEN=$(printf '%s:%s' "$MAVEN_CENTRAL_USERNAME" "$MAVEN_CENTRAL_PASSWORD" | base64 | tr -d '\n')
         echo "::add-mask::$BEARER_TOKEN"
         CURL_CONFIG=$(mktemp)

--- a/.github/actions/publish-ios/action.yml
+++ b/.github/actions/publish-ios/action.yml
@@ -45,6 +45,7 @@ runs:
       with:
         tag: ${{ inputs.version }}
         name: Release ${{ inputs.version }}
+        commit: ${{ github.sha }}
         token: ${{ inputs.github_token }}
         prerelease: ${{ inputs.is_rc == 'true' }}
         generateReleaseNotes: true

--- a/scripts/__tests__/verify_template_test.py
+++ b/scripts/__tests__/verify_template_test.py
@@ -119,6 +119,31 @@ class CocoaPodsCdnTest(unittest.TestCase):
         self.assertFalse(ready)
         self.assertIn("DIProvider", reason)
 
+    def test_wait_for_cocoapods_cdn_polls_pending_pods_together(self):
+        calls = []
+        call_counts = {}
+
+        class PodsConfig:
+            def read_text(self):
+                return '[{"pod_name":"SparklingMacro"},{"pod_name":"SparklingMethod"}]'
+
+        def fake_spec_ready(pod, version):
+            calls.append(pod)
+            call_counts[pod] = call_counts.get(pod, 0) + 1
+            if pod == "SparklingMacro" and call_counts[pod] == 1:
+                return False, f"{pod} {version} pending"
+            return True, f"{pod} {version} ready"
+
+        with (
+            patch.object(verify_template, "IOS_PODS_CONFIG", PodsConfig()),
+            patch.object(verify_template, "cocoapods_cdn_spec_ready", fake_spec_ready),
+            patch.object(verify_template.time, "sleep") as sleep,
+        ):
+            verify_template.wait_for_cocoapods_cdn("2.1.0-rc.30", attempts=2, delay=0)
+
+        self.assertEqual(calls, ["SparklingMacro", "SparklingMethod", "SparklingMacro"])
+        sleep.assert_called_once_with(0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/publish-android-maven.sh
+++ b/scripts/publish-android-maven.sh
@@ -108,6 +108,22 @@ if [[ $VERSION =~ -rc\.[0-9]+$ ]]; then
     print_info "Detected RC version: $VERSION"
 fi
 
+mask_github_value() {
+    if [ "${GITHUB_ACTIONS:-}" != "true" ] || [ -z "${1:-}" ]; then
+        return 0
+    fi
+
+    local value="$1"
+    value="${value//'%'/'%25'}"
+    value="${value//$'\r'/'%0D'}"
+    value="${value//$'\n'/'%0A'}"
+    echo "::add-mask::$value"
+}
+
+set +x
+mask_github_value "${MAVEN_CENTRAL_USERNAME:-}"
+mask_github_value "${MAVEN_CENTRAL_PASSWORD:-}"
+
 # Validate environment variables
 print_info "Checking environment variables..."
 
@@ -258,11 +274,8 @@ print_info "========================================"
 
 NAMESPACE=${SPARKLING_PUBLISHING_GROUP_ID:-"com.tiktok.sparkling"}
 # Build the Bearer token: base64(username:password)
-set +x
 BEARER_TOKEN=$(printf '%s:%s' "$MAVEN_CENTRAL_USERNAME" "$MAVEN_CENTRAL_PASSWORD" | base64 | tr -d '\n')
-if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
-    echo "::add-mask::$BEARER_TOKEN"
-fi
+mask_github_value "$BEARER_TOKEN"
 CURL_CONFIG=$(mktemp)
 trap 'rm -f "$CURL_CONFIG"' EXIT
 chmod 600 "$CURL_CONFIG"

--- a/scripts/publish-android-maven.sh
+++ b/scripts/publish-android-maven.sh
@@ -258,6 +258,7 @@ print_info "========================================"
 
 NAMESPACE=${SPARKLING_PUBLISHING_GROUP_ID:-"com.tiktok.sparkling"}
 # Build the Bearer token: base64(username:password)
+set +x
 BEARER_TOKEN=$(printf '%s:%s' "$MAVEN_CENTRAL_USERNAME" "$MAVEN_CENTRAL_PASSWORD" | base64 | tr -d '\n')
 if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
     echo "::add-mask::$BEARER_TOKEN"

--- a/scripts/publish-android-maven.sh
+++ b/scripts/publish-android-maven.sh
@@ -258,7 +258,14 @@ print_info "========================================"
 
 NAMESPACE=${SPARKLING_PUBLISHING_GROUP_ID:-"com.tiktok.sparkling"}
 # Build the Bearer token: base64(username:password)
-BEARER_TOKEN=$(printf '%s:%s' "$MAVEN_CENTRAL_USERNAME" "$MAVEN_CENTRAL_PASSWORD" | base64)
+BEARER_TOKEN=$(printf '%s:%s' "$MAVEN_CENTRAL_USERNAME" "$MAVEN_CENTRAL_PASSWORD" | base64 | tr -d '\n')
+if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+    echo "::add-mask::$BEARER_TOKEN"
+fi
+CURL_CONFIG=$(mktemp)
+trap 'rm -f "$CURL_CONFIG"' EXIT
+chmod 600 "$CURL_CONFIG"
+printf 'header = "Authorization: Bearer %s"\n' "$BEARER_TOKEN" > "$CURL_CONFIG"
 
 # publishing_type=automatic will auto-release to Maven Central if validation passes
 PUBLISHING_TYPE="automatic"
@@ -266,8 +273,8 @@ PUBLISHING_TYPE="automatic"
 print_info "Transferring deployment to Central Portal (namespace: $NAMESPACE, type: $PUBLISHING_TYPE)..."
 UPLOAD_RESPONSE=$(curl -s -w "\n%{http_code}" \
     -X POST \
-    "https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/${NAMESPACE}?publishing_type=${PUBLISHING_TYPE}" \
-    -H "Authorization: Bearer ${BEARER_TOKEN}")
+    --config "$CURL_CONFIG" \
+    "https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/${NAMESPACE}?publishing_type=${PUBLISHING_TYPE}")
 
 HTTP_CODE=$(echo "$UPLOAD_RESPONSE" | tail -1)
 RESPONSE_BODY=$(echo "$UPLOAD_RESPONSE" | sed '$d')

--- a/scripts/verify_template.py
+++ b/scripts/verify_template.py
@@ -223,27 +223,32 @@ def wait_for_maven(version, attempts=90, delay=20):
         raise SystemExit("::error::Maven artifacts unavailable")
 
 
-def wait_for_cocoapods_cdn(version, attempts=60, delay=30):
+def wait_for_cocoapods_cdn(version, attempts=120, delay=30):
     section("Waiting for CocoaPods CDN podspecs")
     pods = [entry["pod_name"] for entry in json.loads(IOS_PODS_CONFIG.read_text())]
-    missing = []
-    for pod in pods:
-        found = False
-        last_reason = ""
-        for i in range(1, attempts + 1):
+    pending = list(pods)
+    last_reasons = {}
+
+    for i in range(1, attempts + 1):
+        next_pending = []
+        for pod in pending:
             ready, reason = cocoapods_cdn_spec_ready(pod, version)
-            last_reason = reason
             if ready:
                 log(f"  cdn ok: {pod} {version} (after {i} check(s))")
-                found = True
-                break
+                continue
+            last_reasons[pod] = reason
+            next_pending.append(pod)
             log(f"  waiting for CDN {pod} {version}... ({i}/{attempts}, next check in {delay}s): {reason}")
+
+        pending = next_pending
+        if not pending:
+            return
+        if i < attempts:
             time.sleep(delay)
-        if not found:
-            log(f"::error::{pod} {version} not ready on CocoaPods CDN after {attempts * delay}s: {last_reason}")
-            missing.append(pod)
-    if missing:
-        raise SystemExit("::error::CocoaPods CDN podspecs unavailable")
+
+    for pod in pending:
+        log(f"::error::{pod} {version} not ready on CocoaPods CDN after {attempts * delay}s: {last_reasons.get(pod, '<unknown>')}")
+    raise SystemExit("::error::CocoaPods CDN podspecs unavailable")
 
 
 def wait_for_trunk(version, attempts=20, delay=30):


### PR DESCRIPTION
## Summary

Fix the release/template verification path after the failed RC release.

- Poll CocoaPods CDN readiness across all pending pods together instead of checking pods serially.
- Add a regression test for the shared CDN polling window.
- Ensure workflow-dispatch releases create tags at the triggering branch SHA.
- Make Maven Central preflight tolerate transient 403/429/5xx responses after retries, while still validating required secrets.

## Root Cause

The failed release was caused by propagation timing and dependency mode issues around the app template release path. CocoaPods trunk accepted the pod versions before the public CDN `all_pods_versions_*.txt` indexes exposed them, so a direct podspec URL check was not enough to prove a consumer `pod install` could resolve the version. The previous verifier also checked pods serially, allowing one slow CDN index to consume the wait window before later pods were checked.

A later rc run also exposed that workflow-dispatch release tags defaulted to `main` unless the release action was given the triggering SHA explicitly. Maven Central preflight also hit a transient HTTP 403 from the Sonatype staging search endpoint, so the preflight now retries and treats transient infrastructure responses as inconclusive rather than blocking the real publish step.

## Validation

Local:

- `python3 -m unittest scripts.__tests__.verify_template_test`
- YAML parse for the touched workflow/action files
- `git diff --check`

GitHub:

- CI on `codex/release-rc-cdn-wait`: https://github.com/tiktok/sparkling/actions/runs/27062771515
- Final release from this branch: `2.1.0-rc.33` https://github.com/tiktok/sparkling/actions/runs/27063135271
- `refs/tags/2.1.0-rc.33` points to `7256bf7eb19114fda474ca57baf1db30e252afa9`, the branch head.

Artifact checks after release:

- npm packages including `sparkling-app-template@2.1.0-rc.33`
- Maven artifacts including `com.tiktok.sparkling:sparkling-debug-tool:2.1.0-rc.33`
- CocoaPods CDN indexes for all Sparkling pods including `Sparkling-DebugTool 2.1.0-rc.33`