### PR TITLE
feat(ios): add host container integration contracts

### DIFF
--- a/docs/en/apis/sparkling-sdk-ios.md
+++ b/docs/en/apis/sparkling-sdk-ios.md
@@ -83,7 +83,7 @@ Configuration object passed to both container types.
 |----------|-------------|
 | `containerLifecycleDelegate` | Delegate conforming to `SPKContainerLifecycleProtocol` for loading callbacks. |
 | `loadingViewBuilder` | Closure that returns a custom loading view. |
-| `failedViewBuilder` | Closure that returns a custom error view. |
+| `failedViewBuilder` | Main-actor closure that returns a custom error view conforming to `SPKLoadErrorViewProtocol`. The protocol and its refresh callback are main-actor isolated. |
 | `naviBar` | Custom navigation bar (full-page containers only). |
 | `navigationBarBackHandler` | Called on the main thread for a navigation-bar back action before the SDK pops or dismisses. Return `true` after the host performs the navigation mutation; return `false` to keep the SDK default. Weakly capture coordinators that retain the container stack. |
 | `appTheme` | Theme configuration. |

--- a/docs/en/apis/sparkling-sdk-ios.md
+++ b/docs/en/apis/sparkling-sdk-ios.md
@@ -36,6 +36,25 @@ Opens full-page Sparkling containers. See [Containers — Full-page](../guide/co
 | `SPKRouter.close(container:)` | Pops or dismisses the given container. |
 | `SPKRouter.openInSystemBrowser(withURL:)` | Opens an HTTP/HTTPS URL in Safari. |
 
+## SPKHybridSchemeParam
+
+Build canonical full-page Lynx schemes with the SDK instead of assembling or
+percent-encoding the URL by hand.
+
+```swift
+let scheme = try SPKHybridSchemeParam.buildLynxPageScheme(
+    resource: .bundle("detail.lynx.bundle"),
+    queryItems: [URLQueryItem(name: "title", value: "Detail & preview")]
+)
+SPKRouter.open(withURL: scheme.absoluteString, context: nil)
+```
+
+Use `.url("https://example.com/detail.lynx.bundle")` for an absolute remote
+resource URL. The builder rejects empty resources, relative URL resources, and
+additional `bundle` or `url` query items. It preserves the order and duplicates
+of all other query items in the encoded URL and applies one layer of percent
+encoding. Resolver dictionary views remain last-value-wins for duplicate names.
+
 ## SPKContainerView
 
 Embeds Sparkling content as a subview. See [Containers — Embedded](../guide/containers.md#embedded-containers) for usage guide.
@@ -66,6 +85,7 @@ Configuration object passed to both container types.
 | `loadingViewBuilder` | Closure that returns a custom loading view. |
 | `failedViewBuilder` | Closure that returns a custom error view. |
 | `naviBar` | Custom navigation bar (full-page containers only). |
+| `navigationBarBackHandler` | Called on the main thread for a navigation-bar back action before the SDK pops or dismisses. Return `true` after the host performs the navigation mutation; return `false` to keep the SDK default. Weakly capture coordinators that retain the container stack. |
 | `appTheme` | Theme configuration. |
 | `customUIElements` | Custom Lynx UI elements to register. |
 | `extra` | Dictionary of additional data passed to the container. |

--- a/docs/en/apis/sparkling-sdk-ios.md
+++ b/docs/en/apis/sparkling-sdk-ios.md
@@ -85,7 +85,7 @@ Configuration object passed to both container types.
 | `loadingViewBuilder` | Closure that returns a custom loading view. |
 | `failedViewBuilder` | Main-actor closure that returns a custom error view conforming to `SPKLoadErrorViewProtocol`. The protocol and its refresh callback are main-actor isolated. |
 | `naviBar` | Custom navigation bar (full-page containers only). |
-| `navigationBarBackHandler` | Called on the main thread for a navigation-bar back action before the SDK pops or dismisses. Return `true` after the host performs the navigation mutation; return `false` to keep the SDK default. Weakly capture coordinators that retain the container stack. |
+| `navigationBarBackHandler` | Called on the main thread for a navigation-bar back action before the SDK pops or dismisses. Return `true` when the host consumes the action, including an intentional rejection; return `false` only to keep the SDK default. Weakly capture coordinators that retain the container stack. |
 | `appTheme` | Theme configuration. |
 | `customUIElements` | Custom Lynx UI elements to register. |
 | `extra` | Dictionary of additional data passed to the container. |

--- a/docs/en/apis/sparkling-sdk-ios.md
+++ b/docs/en/apis/sparkling-sdk-ios.md
@@ -86,9 +86,23 @@ Configuration object passed to both container types.
 | `failedViewBuilder` | Main-actor closure that returns a custom error view conforming to `SPKLoadErrorViewProtocol`. The protocol and its refresh callback are main-actor isolated. |
 | `naviBar` | Custom navigation bar (full-page containers only). |
 | `navigationBarBackHandler` | Called on the main thread for a navigation-bar back action before the SDK pops or dismisses. Return `true` when the host consumes the action, including an intentional rejection; return `false` only to keep the SDK default. Weakly capture coordinators that retain the container stack. |
+| `interactivePopGestureDelegate` | Weak, main-actor delegate for host-owned system interactive pop. It can reject the gesture before UIKit starts and receives exactly one completion or cancellation callback after every authorized gesture. Sparkling temporarily enables the system recognizer and restores its previous state when the container is no longer active. |
 | `appTheme` | Theme configuration. |
 | `customUIElements` | Custom Lynx UI elements to register. |
 | `extra` | Dictionary of additional data passed to the container. |
+
+## SPKInteractivePopGestureDelegate
+
+Use this delegate only when the host application owns navigation mutations and
+must reserve its stack before UIKit starts a cancellable interactive pop.
+
+| Callback | Description |
+|----------|-------------|
+| `containerShouldBeginInteractivePop(_:)` | Return `false` to reject the gesture before it begins. The default is `true`. |
+| `container(_:didEndInteractivePopCompleted:)` | Called exactly once after an authorized gesture ends. `completed` is `true` for a committed pop and `false` for cancellation. |
+
+Keep the delegate alive for as long as the context is in use; the context holds
+it weakly to avoid a navigation ownership cycle.
 
 ## SPKContainerLifecycleProtocol
 

--- a/docs/en/guide/scheme.md
+++ b/docs/en/guide/scheme.md
@@ -99,11 +99,15 @@ SparklingRouter.open(context, "hybrid://lynxview_page?bundle=detail.lynx.bundle&
 
 **iOS (Swift)**:
 ```swift
-SparklingRouter.open("hybrid://lynxview_page?bundle=detail.lynx.bundle&title=Detail")
+let scheme = try SPKHybridSchemeParam.buildLynxPageScheme(
+    resource: .bundle("detail.lynx.bundle"),
+    queryItems: [URLQueryItem(name: "title", value: "Detail")]
+)
+SPKRouter.open(withURL: scheme.absoluteString, context: nil)
 ```
 
 ## Encoding tips
 
-- Always URL-encode parameter values. Use `URLSearchParams` in JS, `Uri.Builder` on Android, or `URLComponents` on iOS.
+- Always URL-encode parameter values. Use `URLSearchParams` in JS, `Uri.Builder` on Android, or `SPKHybridSchemeParam.buildLynxPageScheme` on iOS.
 - Hex colors must encode `#` as `%23` — otherwise the browser treats everything after `#` as a URL fragment.
 - Stick to 6-digit `#RRGGBB` colors. Android and iOS interpret 8-digit hex differently.

--- a/docs/zh/apis/sparkling-sdk-ios.md
+++ b/docs/zh/apis/sparkling-sdk-ios.md
@@ -84,9 +84,22 @@ SPKRouter.open(withURL: scheme.absoluteString, context: nil)
 | `failedViewBuilder` | 在主 actor 上返回遵循 `SPKLoadErrorViewProtocol` 的自定义错误视图。该协议及其刷新回调均隔离于主 actor。 |
 | `naviBar` | 自定义导航栏（仅全页容器）。 |
 | `navigationBarBackHandler` | 在主线程收到导航栏返回动作，发生于 SDK 执行 pop 或 dismiss 之前。宿主消费该动作（包括明确拒绝导航）时返回 `true`；仅在需要保留 SDK 默认行为时返回 `false`。若 coordinator 持有容器栈，请使用弱引用捕获。 |
+| `interactivePopGestureDelegate` | 弱引用、主 actor 隔离的系统侧滑返回代理，适用于由宿主管理导航栈的场景。它可在 UIKit 开始手势前拒绝操作，并在每次已授权手势结束后恰好收到一次完成或取消回调。容器不再活跃时，Sparkling 会恢复系统手势识别器原有的启用状态。 |
 | `appTheme` | 主题配置。 |
 | `customUIElements` | 需要注册的自定义 Lynx UI 元素。 |
 | `extra` | 传递给容器的额外数据字典。 |
+
+## SPKInteractivePopGestureDelegate
+
+当导航变更由宿主统一管理，并且需要在 UIKit 开始可取消的侧滑返回前预占导航栈时，
+使用该代理。
+
+| 回调 | 说明 |
+|------|------|
+| `containerShouldBeginInteractivePop(_:)` | 在手势开始前返回 `false` 可拒绝操作；默认值为 `true`。 |
+| `container(_:didEndInteractivePopCompleted:)` | 每次已授权手势结束后恰好调用一次。`completed` 为 `true` 表示 pop 已提交，为 `false` 表示已取消。 |
+
+请在 context 使用期间保持代理存活；context 对其使用弱引用，以避免形成导航所有权循环。
 
 ## SPKContainerLifecycleProtocol
 

--- a/docs/zh/apis/sparkling-sdk-ios.md
+++ b/docs/zh/apis/sparkling-sdk-ios.md
@@ -36,6 +36,23 @@ SPKExecuteAllPrepareBootTask()
 | `SPKRouter.close(container:)` | Pop 或 dismiss 指定容器。 |
 | `SPKRouter.openInSystemBrowser(withURL:)` | 在 Safari 中打开 HTTP/HTTPS URL。 |
 
+## SPKHybridSchemeParam
+
+使用 SDK 构建规范的 Lynx 全页 scheme，无需手动拼接 URL 或处理百分号编码。
+
+```swift
+let scheme = try SPKHybridSchemeParam.buildLynxPageScheme(
+    resource: .bundle("detail.lynx.bundle"),
+    queryItems: [URLQueryItem(name: "title", value: "Detail & preview")]
+)
+SPKRouter.open(withURL: scheme.absoluteString, context: nil)
+```
+
+绝对远程资源 URL 使用 `.url("https://example.com/detail.lynx.bundle")`。构建器会拒绝
+空资源、相对 URL 资源以及额外的 `bundle` 或 `url` 查询项；其余查询项的顺序与重复项
+会保留在编码后的 URL 中，并且只进行一层百分号编码。解析器的字典视图对同名项仍采用
+最后一个值优先的语义。
+
 ## SPKContainerView
 
 以子视图形式嵌入 Sparkling 内容。使用指南请参阅[容器 — 嵌入式容器](../guide/containers.md#嵌入式容器)。
@@ -66,6 +83,7 @@ SPKExecuteAllPrepareBootTask()
 | `loadingViewBuilder` | 返回自定义加载视图的闭包。 |
 | `failedViewBuilder` | 返回自定义错误视图的闭包。 |
 | `naviBar` | 自定义导航栏（仅全页容器）。 |
+| `navigationBarBackHandler` | 在主线程收到导航栏返回动作，发生于 SDK 执行 pop 或 dismiss 之前。宿主完成导航变更后返回 `true`；返回 `false` 则保留 SDK 默认行为。若 coordinator 持有容器栈，请使用弱引用捕获。 |
 | `appTheme` | 主题配置。 |
 | `customUIElements` | 需要注册的自定义 Lynx UI 元素。 |
 | `extra` | 传递给容器的额外数据字典。 |

--- a/docs/zh/apis/sparkling-sdk-ios.md
+++ b/docs/zh/apis/sparkling-sdk-ios.md
@@ -83,7 +83,7 @@ SPKRouter.open(withURL: scheme.absoluteString, context: nil)
 | `loadingViewBuilder` | 返回自定义加载视图的闭包。 |
 | `failedViewBuilder` | 在主 actor 上返回遵循 `SPKLoadErrorViewProtocol` 的自定义错误视图。该协议及其刷新回调均隔离于主 actor。 |
 | `naviBar` | 自定义导航栏（仅全页容器）。 |
-| `navigationBarBackHandler` | 在主线程收到导航栏返回动作，发生于 SDK 执行 pop 或 dismiss 之前。宿主完成导航变更后返回 `true`；返回 `false` 则保留 SDK 默认行为。若 coordinator 持有容器栈，请使用弱引用捕获。 |
+| `navigationBarBackHandler` | 在主线程收到导航栏返回动作，发生于 SDK 执行 pop 或 dismiss 之前。宿主消费该动作（包括明确拒绝导航）时返回 `true`；仅在需要保留 SDK 默认行为时返回 `false`。若 coordinator 持有容器栈，请使用弱引用捕获。 |
 | `appTheme` | 主题配置。 |
 | `customUIElements` | 需要注册的自定义 Lynx UI 元素。 |
 | `extra` | 传递给容器的额外数据字典。 |

--- a/docs/zh/apis/sparkling-sdk-ios.md
+++ b/docs/zh/apis/sparkling-sdk-ios.md
@@ -81,7 +81,7 @@ SPKRouter.open(withURL: scheme.absoluteString, context: nil)
 |------|------|
 | `containerLifecycleDelegate` | 遵循 `SPKContainerLifecycleProtocol` 的回调代理。 |
 | `loadingViewBuilder` | 返回自定义加载视图的闭包。 |
-| `failedViewBuilder` | 返回自定义错误视图的闭包。 |
+| `failedViewBuilder` | 在主 actor 上返回遵循 `SPKLoadErrorViewProtocol` 的自定义错误视图。该协议及其刷新回调均隔离于主 actor。 |
 | `naviBar` | 自定义导航栏（仅全页容器）。 |
 | `navigationBarBackHandler` | 在主线程收到导航栏返回动作，发生于 SDK 执行 pop 或 dismiss 之前。宿主完成导航变更后返回 `true`；返回 `false` 则保留 SDK 默认行为。若 coordinator 持有容器栈，请使用弱引用捕获。 |
 | `appTheme` | 主题配置。 |

--- a/docs/zh/guide/scheme.md
+++ b/docs/zh/guide/scheme.md
@@ -101,11 +101,15 @@ SparklingRouter.open(context, "hybrid://lynxview_page?bundle=detail.lynx.bundle&
 
 **iOS (Swift)**：
 ```swift
-SparklingRouter.open("hybrid://lynxview_page?bundle=detail.lynx.bundle&title=Detail")
+let scheme = try SPKHybridSchemeParam.buildLynxPageScheme(
+    resource: .bundle("detail.lynx.bundle"),
+    queryItems: [URLQueryItem(name: "title", value: "Detail")]
+)
+SPKRouter.open(withURL: scheme.absoluteString, context: nil)
 ```
 
 ## 编码提示
 
-- 始终对参数值进行 URL 编码。在 JS 中使用 `URLSearchParams`，Android 上使用 `Uri.Builder`，iOS 上使用 `URLComponents`。
+- 始终对参数值进行 URL 编码。在 JS 中使用 `URLSearchParams`，Android 上使用 `Uri.Builder`，iOS 上使用 `SPKHybridSchemeParam.buildLynxPageScheme`。
 - 十六进制颜色必须将 `#` 编码为 `%23` —— 否则浏览器会将 `#` 之后的内容当作 URL fragment。
 - 使用 6 位 `#RRGGBB` 颜色。Android 和 iOS 对 8 位十六进制的解析方式不同。

--- a/packages/playground/ios/SparklingGoTests/Application/SPKRouterTests.swift
+++ b/packages/playground/ios/SparklingGoTests/Application/SPKRouterTests.swift
@@ -228,4 +228,66 @@ struct SPKRouterTests {
 
         #expect(context.originURL != nil)
     }
+
+    @Test func failedViewBuilderReturnsRegisteredLoadErrorView() {
+        let failedView = TestLoadErrorView()
+        let context = SPKContext()
+        context.failedViewBuilder = { _ in failedView }
+        let config = SPKSchemeParam()
+        let viewController = SPKViewController(
+            withURL: nil,
+            config: config,
+            context: context,
+            frame: .zero)
+
+        let builtView = viewController.buildLoadErrorView()
+
+        #expect(builtView === failedView)
+        #expect(failedView.didRegisterRefresh)
+    }
+
+    @Test func hostNavigationBarBackHandlerCanOwnStackMutation() {
+        let context = SPKContext()
+        var receivedContainer: SPKContainerProtocol?
+        context.navigationBarBackHandler = { container in
+            receivedContainer = container
+            return true
+        }
+        let viewController = SPKRouter.create(
+            withURL: "hybrid://lynxview_page?bundle=main.lynx.bundle",
+            context: context,
+            frame: .zero)
+        let rootViewController = UIViewController()
+        let navigationController = UINavigationController(rootViewController: rootViewController)
+        navigationController.pushViewController(viewController, animated: false)
+
+        (viewController as? SPKViewController)?.didTapLeftButton()
+
+        #expect(receivedContainer === viewController)
+        #expect(navigationController.topViewController === viewController)
+    }
+
+    @Test func navigationBarBackHandlerCanPreserveDefaultPop() {
+        let context = SPKContext()
+        context.navigationBarBackHandler = { _ in false }
+        let viewController = SPKRouter.create(
+            withURL: "hybrid://lynxview_page?bundle=main.lynx.bundle",
+            context: context,
+            frame: .zero)
+        let rootViewController = UIViewController()
+        let navigationController = UINavigationController(rootViewController: rootViewController)
+        navigationController.pushViewController(viewController, animated: false)
+
+        (viewController as? SPKViewController)?.didTapLeftButton()
+
+        #expect(navigationController.topViewController === rootViewController)
+    }
+}
+
+private final class TestLoadErrorView: UIView, SPKLoadErrorViewProtocol {
+    var didRegisterRefresh = false
+
+    func register(refreshBlock: SPKLoadErrorRefreshBlock) {
+        didRegisterRefresh = true
+    }
 }

--- a/packages/playground/ios/SparklingGoTests/Application/SPKRouterTests.swift
+++ b/packages/playground/ios/SparklingGoTests/Application/SPKRouterTests.swift
@@ -244,6 +244,7 @@ struct SPKRouterTests {
 
         #expect(builtView === failedView)
         #expect(failedView.refreshBlock != nil)
+        #expect(failedView.registeredOnMainThread)
     }
 
     @Test func hostNavigationBarBackHandlerCanOwnStackMutation() {
@@ -286,8 +287,10 @@ struct SPKRouterTests {
 
 private final class TestLoadErrorView: UIView, SPKLoadErrorViewProtocol {
     var refreshBlock: SPKLoadErrorRefreshBlock?
+    var registeredOnMainThread = false
 
     func register(refreshBlock: @escaping SPKLoadErrorRefreshBlock) {
         self.refreshBlock = refreshBlock
+        self.registeredOnMainThread = Thread.isMainThread
     }
 }

--- a/packages/playground/ios/SparklingGoTests/Application/SPKRouterTests.swift
+++ b/packages/playground/ios/SparklingGoTests/Application/SPKRouterTests.swift
@@ -283,6 +283,132 @@ struct SPKRouterTests {
 
         #expect(navigationController.topViewController === rootViewController)
     }
+
+    @Test func hostInteractivePopGestureDelegateCanAuthorizeGesture() {
+        let context = SPKContext()
+        let delegate = TestInteractivePopGestureDelegate(shouldBegin: true)
+        context.interactivePopGestureDelegate = delegate
+        let viewController = SPKRouter.create(
+            withURL: "hybrid://lynxview_page?bundle=main.lynx.bundle",
+            context: context,
+            frame: .zero)
+        let rootViewController = UIViewController()
+        let navigationController = UINavigationController(rootViewController: rootViewController)
+        navigationController.pushViewController(viewController, animated: false)
+        let gesture = navigationController.interactivePopGestureRecognizer!
+
+        let shouldBegin = (viewController as? SPKViewController)?
+            .gestureRecognizerShouldBegin(gesture)
+
+        #expect(delegate.receivedContainer === viewController)
+        #expect(shouldBegin == true)
+    }
+
+    @Test func hostInteractivePopGestureDelegateCanDenyGesture() {
+        let context = SPKContext()
+        let delegate = TestInteractivePopGestureDelegate(shouldBegin: false)
+        context.interactivePopGestureDelegate = delegate
+        let viewController = SPKRouter.create(
+            withURL: "hybrid://lynxview_page?bundle=main.lynx.bundle",
+            context: context,
+            frame: .zero)
+        let rootViewController = UIViewController()
+        let navigationController = UINavigationController(rootViewController: rootViewController)
+        navigationController.pushViewController(viewController, animated: false)
+        let gesture = navigationController.interactivePopGestureRecognizer!
+
+        let shouldBegin = (viewController as? SPKViewController)?
+            .gestureRecognizerShouldBegin(gesture)
+
+        #expect(delegate.receivedContainer === viewController)
+        #expect(shouldBegin == false)
+    }
+
+    @Test func hostInteractivePopGestureDelegateReceivesOneCompletion() {
+        let context = SPKContext()
+        let delegate = TestInteractivePopGestureDelegate(shouldBegin: true)
+        context.interactivePopGestureDelegate = delegate
+        let viewController = SPKRouter.create(
+            withURL: "hybrid://lynxview_page?bundle=main.lynx.bundle",
+            context: context,
+            frame: .zero)
+        let rootViewController = UIViewController()
+        let navigationController = UINavigationController(rootViewController: rootViewController)
+        navigationController.pushViewController(viewController, animated: false)
+        let sparklingViewController = viewController as? SPKViewController
+        let gesture = navigationController.interactivePopGestureRecognizer!
+        _ = sparklingViewController?.gestureRecognizerShouldBegin(gesture)
+
+        sparklingViewController?.notifyHostInteractivePopDidEnd(completed: true)
+        sparklingViewController?.notifyHostInteractivePopDidEnd(completed: false)
+
+        #expect(delegate.completions == [true])
+    }
+
+    @Test func hostInteractivePopGestureDelegateReceivesCancellation() {
+        let context = SPKContext()
+        let delegate = TestInteractivePopGestureDelegate(shouldBegin: true)
+        context.interactivePopGestureDelegate = delegate
+        let viewController = SPKRouter.create(
+            withURL: "hybrid://lynxview_page?bundle=main.lynx.bundle",
+            context: context,
+            frame: .zero)
+        let rootViewController = UIViewController()
+        let navigationController = UINavigationController(rootViewController: rootViewController)
+        navigationController.pushViewController(viewController, animated: false)
+        let sparklingViewController = viewController as? SPKViewController
+        _ = sparklingViewController?.gestureRecognizerShouldBegin(
+            navigationController.interactivePopGestureRecognizer!)
+
+        sparklingViewController?.notifyHostInteractivePopDidEnd(completed: false)
+
+        #expect(delegate.completions == [false])
+    }
+
+    @Test func managedInteractivePopTemporarilyEnablesSystemGesture() {
+        let context = SPKContext()
+        let delegate = TestInteractivePopGestureDelegate(shouldBegin: true)
+        context.interactivePopGestureDelegate = delegate
+        let viewController = SPKRouter.create(
+            withURL: "hybrid://lynxview_page?bundle=main.lynx.bundle",
+            context: context,
+            frame: .zero)
+        let rootViewController = UIViewController()
+        let navigationController = UINavigationController(rootViewController: rootViewController)
+        navigationController.pushViewController(viewController, animated: false)
+        let gesture = navigationController.interactivePopGestureRecognizer!
+        gesture.isEnabled = false
+        let sparklingViewController = viewController as? SPKViewController
+
+        sparklingViewController?.viewDidAppear(false)
+
+        #expect(gesture.isEnabled)
+        sparklingViewController?.viewWillDisappear(false)
+        #expect(!gesture.isEnabled)
+    }
+}
+
+private final class TestInteractivePopGestureDelegate: NSObject, SPKInteractivePopGestureDelegate {
+    let shouldBegin: Bool
+    var receivedContainer: SPKContainerProtocol?
+    var completions: [Bool] = []
+
+    init(shouldBegin: Bool) {
+        self.shouldBegin = shouldBegin
+    }
+
+    func containerShouldBeginInteractivePop(_ container: SPKContainerProtocol) -> Bool {
+        receivedContainer = container
+        return shouldBegin
+    }
+
+    func container(
+        _ container: SPKContainerProtocol,
+        didEndInteractivePopCompleted completed: Bool
+    ) {
+        receivedContainer = container
+        completions.append(completed)
+    }
 }
 
 private final class TestLoadErrorView: UIView, SPKLoadErrorViewProtocol {

--- a/packages/playground/ios/SparklingGoTests/Application/SPKRouterTests.swift
+++ b/packages/playground/ios/SparklingGoTests/Application/SPKRouterTests.swift
@@ -243,7 +243,7 @@ struct SPKRouterTests {
         let builtView = viewController.buildLoadErrorView()
 
         #expect(builtView === failedView)
-        #expect(failedView.didRegisterRefresh)
+        #expect(failedView.refreshBlock != nil)
     }
 
     @Test func hostNavigationBarBackHandlerCanOwnStackMutation() {
@@ -285,9 +285,9 @@ struct SPKRouterTests {
 }
 
 private final class TestLoadErrorView: UIView, SPKLoadErrorViewProtocol {
-    var didRegisterRefresh = false
+    var refreshBlock: SPKLoadErrorRefreshBlock?
 
-    func register(refreshBlock: SPKLoadErrorRefreshBlock) {
-        didRegisterRefresh = true
+    func register(refreshBlock: @escaping SPKLoadErrorRefreshBlock) {
+        self.refreshBlock = refreshBlock
     }
 }

--- a/packages/playground/ios/SparklingGoTests/Application/SPKSchemeTests.swift
+++ b/packages/playground/ios/SparklingGoTests/Application/SPKSchemeTests.swift
@@ -283,7 +283,7 @@ struct SPKContextTests {
         #expect(context.naviBar === naviBar)
     }
 
-    @Test func copyMethod() {
+    @Test @MainActor func copyMethod() {
         let originalContext = SPKContext()
         // SPKContext doesn't have title property
         originalContext.originURL = "hybrid://lynxview_page?bundle=.%2Fmain.lynx.bundle"

--- a/packages/playground/ios/SparklingGoTests/Application/SPKSchemeTests.swift
+++ b/packages/playground/ios/SparklingGoTests/Application/SPKSchemeTests.swift
@@ -288,6 +288,8 @@ struct SPKContextTests {
         // SPKContext doesn't have title property
         originalContext.originURL = "hybrid://lynxview_page?bundle=.%2Fmain.lynx.bundle"
         originalContext.navigationBarBackHandler = { _ in true }
+        let interactivePopGestureDelegate = TestSchemeInteractivePopGestureDelegate()
+        originalContext.interactivePopGestureDelegate = interactivePopGestureDelegate
 
         let copiedContext = originalContext.copy() as? SPKContext
 
@@ -295,6 +297,7 @@ struct SPKContextTests {
         // SPKContext doesn't have title property
         #expect(copiedContext?.originURL == "hybrid://lynxview_page?bundle=.%2Fmain.lynx.bundle")
         #expect(copiedContext?.navigationBarBackHandler != nil)
+        #expect(copiedContext?.interactivePopGestureDelegate === interactivePopGestureDelegate)
         #expect(copiedContext !== originalContext)
     }
 
@@ -321,4 +324,9 @@ struct SPKContextTests {
 
         #expect(weakContext == nil)
     }
+}
+
+private final class TestSchemeInteractivePopGestureDelegate: NSObject,
+    SPKInteractivePopGestureDelegate
+{
 }

--- a/packages/playground/ios/SparklingGoTests/Application/SPKSchemeTests.swift
+++ b/packages/playground/ios/SparklingGoTests/Application/SPKSchemeTests.swift
@@ -287,12 +287,14 @@ struct SPKContextTests {
         let originalContext = SPKContext()
         // SPKContext doesn't have title property
         originalContext.originURL = "hybrid://lynxview_page?bundle=.%2Fmain.lynx.bundle"
+        originalContext.navigationBarBackHandler = { _ in true }
 
         let copiedContext = originalContext.copy() as? SPKContext
 
         #expect(copiedContext != nil)
         // SPKContext doesn't have title property
         #expect(copiedContext?.originURL == "hybrid://lynxview_page?bundle=.%2Fmain.lynx.bundle")
+        #expect(copiedContext?.navigationBarBackHandler != nil)
         #expect(copiedContext !== originalContext)
     }
 

--- a/packages/playground/ios/SparklingGoTests/Application/SPKSchemeTests.swift
+++ b/packages/playground/ios/SparklingGoTests/Application/SPKSchemeTests.swift
@@ -301,6 +301,18 @@ struct SPKContextTests {
         #expect(copiedContext !== originalContext)
     }
 
+    @Test func copyPreservesLynxModuleAndCustomUIElements() {
+        let originalContext = SPKContext()
+        let customElement = NSObject()
+        originalContext.lynxModule = ["module": "host-owned-module"]
+        originalContext.customUIElements = [customElement]
+
+        let copiedContext = originalContext.copy() as? SPKContext
+
+        #expect(copiedContext?.lynxModule?["module"] as? String == "host-owned-module")
+        #expect(copiedContext?.customUIElements?.first as? NSObject === customElement)
+    }
+
     @Test func propertyUpdates() {
         let context = SPKContext()
 

--- a/packages/playground/ios/SparklingGoTests/Application/SPKViewTests.swift
+++ b/packages/playground/ios/SparklingGoTests/Application/SPKViewTests.swift
@@ -2,6 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import Lynx
 import Testing
 import UIKit
 
@@ -22,6 +23,44 @@ struct SPKViewTests {
         #expect(view.sparkContentMode == .SPKContainerViewContentModeFixedSize)
         #expect(view.hybridInBackground == false)
         #expect(view.viewType == .SPKHybridEngineTypeUnknown)
+    }
+
+    @Test func containerDefaultGlobalPropsPreservePageVersion() {
+        let context = SPKContext()
+        context.globalProps = ["SPK_version": "page-owned-version"]
+        let view = SPKContainerView()
+        view.context = context
+
+        view.addContainerDefaultGlobalProps()
+
+        let globalProps = context.globalProps as? [String: Any]
+        #expect(globalProps?["SPK_version"] as? String == "page-owned-version")
+    }
+
+    @Test func containerDefaultGlobalPropsPreserveTemplateDataPageVersion() throws {
+        let context = SPKContext()
+        context.globalProps = try #require(
+            LynxTemplateData(dictionary: ["SPK_version": "page-template-version"]))
+        let view = SPKContainerView()
+        view.context = context
+
+        view.addContainerDefaultGlobalProps()
+
+        let globalProps = (context.globalProps as? LynxTemplateData)?.dictionary()
+        #expect(globalProps?["SPK_version"] as? String == "page-template-version")
+    }
+
+    @Test func containerDefaultGlobalPropsFillMissingVersion() {
+        let context = SPKContext()
+        context.globalProps = ["page": "value"]
+        let view = SPKContainerView()
+        view.context = context
+
+        view.addContainerDefaultGlobalProps()
+
+        let globalProps = context.globalProps as? [String: Any]
+        #expect((globalProps?["SPK_version"] as? String)?.isEmpty == false)
+        #expect(globalProps?["page"] as? String == "value")
     }
 
     @Test func loadWithURL() {

--- a/packages/playground/ios/SparklingGoTests/Service/SPKHybridContextTests.swift
+++ b/packages/playground/ios/SparklingGoTests/Service/SPKHybridContextTests.swift
@@ -50,7 +50,7 @@ struct SPKHybridContextTests {
 
         #expect(merged1?["a"] as? Int == 1)
         #expect(merged2?["a"] as? Int == 1)
-        #expect(merged3?.isEmpty == true)
+        #expect(merged3 == nil)
     }
 
     @Test func testMergeWithEmptyDictionaries() {
@@ -101,10 +101,12 @@ struct SPKHybridContextTests {
         let merged1 = SPKHybridContext.merge(withArray: source, to: []) as? [Int]
         let merged2 = SPKHybridContext.merge(withArray: nil, to: source) as? [Int]
         let merged3 = SPKHybridContext.merge(withArray: nil, to: [])
+        let merged4 = SPKHybridContext.merge(withArray: nil, to: nil)
 
         #expect(merged1 == source)
         #expect(merged2 == source)
         #expect(merged3?.isEmpty == true)
+        #expect(merged4 == nil)
     }
 
     // MARK: - Context Merge Tests

--- a/packages/playground/ios/SparklingGoTests/Service/SPKHybridContextTests.swift
+++ b/packages/playground/ios/SparklingGoTests/Service/SPKHybridContextTests.swift
@@ -48,9 +48,9 @@ struct SPKHybridContextTests {
         let merged2 = SPKHybridContext.merge(withDict: nil, to: dict1, isOverride: true)
         let merged3 = SPKHybridContext.merge(withDict: nil, to: nil, isOverride: true)
 
-        #expect(merged1 == nil)
-        #expect(merged2 == nil)
-        #expect(merged3 == nil)
+        #expect(merged1?["a"] as? Int == 1)
+        #expect(merged2?["a"] as? Int == 1)
+        #expect(merged3?.isEmpty == true)
     }
 
     @Test func testMergeWithEmptyDictionaries() {
@@ -103,8 +103,8 @@ struct SPKHybridContextTests {
         let merged3 = SPKHybridContext.merge(withArray: nil, to: [])
 
         #expect(merged1 == source)
-        #expect(merged2 == nil)
-        #expect(merged3 == nil)
+        #expect(merged2 == source)
+        #expect(merged3?.isEmpty == true)
     }
 
     // MARK: - Context Merge Tests

--- a/packages/playground/ios/SparklingGoTests/Service/SPKHybridSchemeParamTests.swift
+++ b/packages/playground/ios/SparklingGoTests/Service/SPKHybridSchemeParamTests.swift
@@ -281,4 +281,81 @@ struct SPKHybridSchemeParamTests {
         #expect(param.extra.count >= 1000)
         #expect(endTime - startTime < 1.0)  // Should complete within 1 second
     }
+
+    // MARK: - Canonical Scheme Builder Tests
+
+    @Test func testBuildLynxPageBundleSchemePreservesOrderedQueryItems() throws {
+        let url = try SPKHybridSchemeParam.buildLynxPageScheme(
+            resource: .bundle("nav-basic.lynx.bundle"),
+            queryItems: [
+                URLQueryItem(name: "title", value: "Navigation & routing"),
+                URLQueryItem(name: "experiment", value: "first"),
+                URLQueryItem(name: "experiment", value: "second")
+            ])
+
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        #expect(components?.scheme == "hybrid")
+        #expect(components?.host == "lynxview_page")
+        #expect(components?.queryItems?.map(\.name) == ["bundle", "title", "experiment", "experiment"])
+        #expect(
+            components?.queryItems?.map(\.value) == [
+                "nav-basic.lynx.bundle", "Navigation & routing", "first", "second"
+            ])
+
+        let resolved = SPKHybridSchemeParam.resolver(withScheme: url)
+        #expect(resolved.engineType == .SPKHybridEngineTypeLynx)
+        #expect(resolved.containerType == .SPKHybridContainerTypePage)
+    }
+
+    @Test func testBuildLynxPageURLSchemeEncodesTargetOnce() throws {
+        let resource = "https://example.com/main.lynx.bundle?message=A%20B&comparison=a=b"
+        let url = try SPKHybridSchemeParam.buildLynxPageScheme(
+            resource: .url(resource),
+            queryItems: [URLQueryItem(name: "title", value: "A & B = C")])
+
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        #expect(components?.queryItems?.first?.name == "url")
+        #expect(components?.queryItems?.first?.value == resource)
+        #expect(components?.queryItems?.last?.value == "A & B = C")
+
+        let resolved = SPKHybridSchemeParam.resolver(withScheme: url)
+        #expect(resolved.url == resource)
+        #expect(resolved.engineType == .SPKHybridEngineTypeLynx)
+        #expect(resolved.containerType == .SPKHybridContainerTypePage)
+    }
+
+    @Test func testBuildLynxPageSchemeRejectsReservedTargets() {
+        var caughtError: SPKHybridSchemeBuilderError?
+        do {
+            _ = try SPKHybridSchemeParam.buildLynxPageScheme(
+                resource: .bundle("main.lynx.bundle"),
+                queryItems: [URLQueryItem(name: "url", value: "https://example.com")])
+        } catch let error as SPKHybridSchemeBuilderError {
+            caughtError = error
+        } catch {}
+
+        #expect(caughtError == .reservedQueryItem("url"))
+    }
+
+    @Test func testBuildLynxPageSchemeRejectsEmptyResource() {
+        var caughtError: SPKHybridSchemeBuilderError?
+        do {
+            _ = try SPKHybridSchemeParam.buildLynxPageScheme(resource: .bundle("  \n"))
+        } catch let error as SPKHybridSchemeBuilderError {
+            caughtError = error
+        } catch {}
+
+        #expect(caughtError == .emptyResource)
+    }
+
+    @Test func testBuildLynxPageSchemeRejectsRelativeURLResource() {
+        var caughtError: SPKHybridSchemeBuilderError?
+        do {
+            _ = try SPKHybridSchemeParam.buildLynxPageScheme(resource: .url("relative/main.lynx.bundle"))
+        } catch let error as SPKHybridSchemeBuilderError {
+            caughtError = error
+        } catch {}
+
+        #expect(caughtError == .invalidResourceURL("relative/main.lynx.bundle"))
+    }
 }

--- a/packages/playground/ios/SparklingGoTests/Service/SPKKitUtilsTests.swift
+++ b/packages/playground/ios/SparklingGoTests/Service/SPKKitUtilsTests.swift
@@ -29,6 +29,17 @@ struct SPKKitUtilsTests {
         return context
     }
 
+    @Test func testLynxKitParamsKeepsOuterURLResourceWhenInnerQueryContainsBundle() throws {
+        let resource = "https://example.com/main.lynx.bundle?bundle=shadow.lynx.bundle"
+        let scheme = try SPKHybridSchemeParam.buildLynxPageScheme(resource: .url(resource))
+        let context = SPKHybridContext()
+        context.schemeParams = SPKHybridSchemeParam.resolver(withScheme: scheme)
+
+        let params = SPKLynxKitUtils.lynxKitParams(withContext: context)
+
+        #expect(params.sourceUrl == resource)
+    }
+
     // MARK: - updateGlobalProps Tests
 
     @Test func testUpdateGlobalPropsWithNilContext() {

--- a/packages/sparkling-sdk/ios/Sparkling/Sources/Application/Container/SPKContainerView.swift
+++ b/packages/sparkling-sdk/ios/Sparkling/Sources/Application/Container/SPKContainerView.swift
@@ -290,9 +290,9 @@ open class SPKContainerView: UIView, SPKContainerProtocol {
     /// This method updates the global properties with essential container information
     /// including the SPK framework version for proper initialization and tracking.
     public func addContainerDefaultGlobalProps() {
-        SPKKitUtils.updateGlobalProps(
+        SPKKitUtils.addDefaultGlobalProps(
             withContext: self.context,
-            newGlobalProps: [
+            defaultGlobalProps: [
                 "SPK_version": SPKVersion.SPKVersion()
             ])
         return

--- a/packages/sparkling-sdk/ios/Sparkling/Sources/Application/Container/SPKViewController.swift
+++ b/packages/sparkling-sdk/ios/Sparkling/Sources/Application/Container/SPKViewController.swift
@@ -598,6 +598,12 @@ open class SPKViewController: UIViewController, SPKContainerProtocol {
                 SPKEvent.Back.actionFromKey: SPKEvent.Back.actionTypeNavBarBackPress,
             ])
 
+        if let navigationBarBackHandler = (self.context as? SPKContext)?.navigationBarBackHandler,
+            navigationBarBackHandler(self)
+        {
+            return
+        }
+
         if self.navigationController?.viewControllers.count ?? 0 > 1 {
             //MARK: currently only support lynx
             self.navigationController?.popViewController(animated: true)
@@ -952,7 +958,7 @@ extension SPKViewController: SPKContainerLifecycleProtocol {
             self?.handleErrorViewReload()
         })
 
-        return nil
+        return loadFailedView
     }
 
     func handleErrorViewReload() {

--- a/packages/sparkling-sdk/ios/Sparkling/Sources/Application/Container/SPKViewController.swift
+++ b/packages/sparkling-sdk/ios/Sparkling/Sources/Application/Container/SPKViewController.swift
@@ -234,6 +234,8 @@ open class SPKViewController: UIViewController, SPKContainerProtocol {
     weak var originalNavigationControllerDelegate: UINavigationControllerDelegate?
     weak var oldDelegate: UIGestureRecognizerDelegate?
 
+    private var hostInteractivePopInFlight = false
+
     private var containerFrame: CGRect = UIScreen.main.bounds
 
     /// Used to refresh SnapKit constraints when safe-area insets become valid after the first layout (SwiftUI / multi-scene).
@@ -363,9 +365,12 @@ open class SPKViewController: UIViewController, SPKContainerProtocol {
     public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         self.oldDelegate = self.navigationController?.interactivePopGestureRecognizer?.delegate
-        self.navigationController?.interactivePopGestureRecognizer?.delegate = self
         self.originControllerPopGestureRecongnizerEnabled =
             self.navigationController?.interactivePopGestureRecognizer?.isEnabled ?? self.originControllerPopGestureRecongnizerEnabled
+        self.navigationController?.interactivePopGestureRecognizer?.delegate = self
+        if (self.context as? SPKContext)?.interactivePopGestureDelegate != nil {
+            self.navigationController?.interactivePopGestureRecognizer?.isEnabled = true
+        }
 
         self.originStatusBarStyle = self.statusBarStyle
         self.updateStatusBarStatus()
@@ -385,15 +390,18 @@ open class SPKViewController: UIViewController, SPKContainerProtocol {
     /// - Parameter animated: Whether the disappearance is animated
     public override func viewWillDisappear(_ animated: Bool) {
         self.transitionCoordinator?.notifyWhenInteractionChanges { [weak self] context in
-            if context.isCancelled {
+            guard let self else {
                 return
             }
-            self?.send(
-                event: SPKEvent.Back.finishBack,
-                params: [
-                    SPKEvent.Common.containerIdKey: self?.containerID ?? "",
-                    SPKEvent.Back.actionFromKey: SPKEvent.Back.actionTypeSwipe,
-                ], callback: nil)
+            if !context.isCancelled {
+                self.send(
+                    event: SPKEvent.Back.finishBack,
+                    params: [
+                        SPKEvent.Common.containerIdKey: self.containerID,
+                        SPKEvent.Back.actionFromKey: SPKEvent.Back.actionTypeSwipe,
+                    ], callback: nil)
+            }
+            self.notifyHostInteractivePopDidEnd(completed: !context.isCancelled)
         }
 
         self.navigationController?.interactivePopGestureRecognizer?.delegate = self.oldDelegate
@@ -1029,10 +1037,29 @@ extension SPKViewController: UINavigationControllerDelegate {
 extension SPKViewController: UIGestureRecognizerDelegate {
 
     public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        if gestureRecognizer === self.navigationController?.interactivePopGestureRecognizer,
+            let delegate = (self.context as? SPKContext)?.interactivePopGestureDelegate
+        {
+            let shouldBegin = delegate.containerShouldBeginInteractivePop?(self) ?? true
+            guard shouldBegin else {
+                return false
+            }
+            self.hostInteractivePopInFlight = true
+        }
         if !self.panToCloseGestureControlByExternal {
             self.reportPangestureEvent()
         }
         return true
+    }
+
+    func notifyHostInteractivePopDidEnd(completed: Bool) {
+        guard self.hostInteractivePopInFlight else {
+            return
+        }
+        self.hostInteractivePopInFlight = false
+        (self.context as? SPKContext)?.interactivePopGestureDelegate?.container?(
+            self,
+            didEndInteractivePopCompleted: completed)
     }
 
     func reportPangestureEvent() {

--- a/packages/sparkling-sdk/ios/Sparkling/Sources/Application/Scheme/SPKContext.swift
+++ b/packages/sparkling-sdk/ios/Sparkling/Sources/Application/Scheme/SPKContext.swift
@@ -12,13 +12,12 @@ public typealias SPKLoadingViewBuilder = () -> (UIView & SPKLoadingViewProtocol)
 
 /// Type alias for a closure that creates error view instances.
 ///
-/// This closure takes a view controller and error style, then returns a view that conforms
+/// This main-actor-isolated closure takes a view controller, then returns a view that conforms
 /// to both UIView and SPKLoadErrorViewProtocol for displaying load failures.
 ///
 /// - Parameters:
 ///   - UIViewController: The container view controller where the error view will be displayed
-///   - SPKLoadErrorViewStyle: The style configuration for the error view
-public typealias SPKFailedViewBuilder = (UIViewController?) -> (UIView & SPKLoadErrorViewProtocol)
+public typealias SPKFailedViewBuilder = @MainActor (UIViewController?) -> (UIView & SPKLoadErrorViewProtocol)
 
 public typealias SPKNavigationBarButtonItemBuilder = ((UIViewController & SPKContainerProtocol)?) -> SPKNavigationBarButtonItem?
 

--- a/packages/sparkling-sdk/ios/Sparkling/Sources/Application/Scheme/SPKContext.swift
+++ b/packages/sparkling-sdk/ios/Sparkling/Sources/Application/Scheme/SPKContext.swift
@@ -22,9 +22,11 @@ public typealias SPKFailedViewBuilder = @MainActor (UIViewController?) -> (UIVie
 public typealias SPKNavigationBarButtonItemBuilder = ((UIViewController & SPKContainerProtocol)?) -> SPKNavigationBarButtonItem?
 
 /// Handles a navigation-bar back action before Sparkling performs its default pop or dismissal.
-/// Return `true` when the host application completed the navigation mutation.
-/// Sparkling invokes the handler on the main thread. Hosts should weakly capture
-/// navigation coordinators that retain the container stack.
+/// Return `true` when the host application consumed the back action, including
+/// when it intentionally rejects the navigation mutation. Return `false` only
+/// to let Sparkling perform its default container pop behavior. Sparkling invokes
+/// the handler on the main thread. Hosts should weakly capture navigation
+/// coordinators that retain the container stack.
 public typealias SPKNavigationBarBackHandler = (UIViewController & SPKContainerProtocol) -> Bool
 
 /// Lets a host serialize Sparkling's system interactive-pop gesture with its

--- a/packages/sparkling-sdk/ios/Sparkling/Sources/Application/Scheme/SPKContext.swift
+++ b/packages/sparkling-sdk/ios/Sparkling/Sources/Application/Scheme/SPKContext.swift
@@ -22,6 +22,12 @@ public typealias SPKFailedViewBuilder = (UIViewController?) -> (UIView & SPKLoad
 
 public typealias SPKNavigationBarButtonItemBuilder = ((UIViewController & SPKContainerProtocol)?) -> SPKNavigationBarButtonItem?
 
+/// Handles a navigation-bar back action before Sparkling performs its default pop or dismissal.
+/// Return `true` when the host application completed the navigation mutation.
+/// Sparkling invokes the handler on the main thread. Hosts should weakly capture
+/// navigation coordinators that retain the container stack.
+public typealias SPKNavigationBarBackHandler = (UIViewController & SPKContainerProtocol) -> Bool
+
 /// Enumeration defining the available app theme modes.
 ///
 /// This enum provides theme options for customizing the visual appearance
@@ -110,6 +116,10 @@ open class SPKContext: SPKHybridContext {
 
     public var rightNavigationBarButtonItemBuilder: SPKNavigationBarButtonItemBuilder?
 
+    /// Lets an embedding application own its navigation stack without replacing
+    /// Sparkling's navigation UI. Returning false preserves the SDK default.
+    public var navigationBarBackHandler: SPKNavigationBarBackHandler?
+
     /// Creates a copy of the current SPKContext instance.
     ///
     /// This method implements NSCopying protocol to create a deep copy of the context.
@@ -197,6 +207,12 @@ open class SPKContext: SPKHybridContext {
         self.rightNavigationBarButtonItemBuilder =
             SPKHybridContext.merge(withProp: context.rightNavigationBarButtonItemBuilder, to: self.rightNavigationBarButtonItemBuilder, isOverride: isOverride)
             as? SPKNavigationBarButtonItemBuilder
+
+        self.navigationBarBackHandler =
+            SPKHybridContext.merge(
+                withProp: context.navigationBarBackHandler,
+                to: self.navigationBarBackHandler,
+                isOverride: isOverride) as? SPKNavigationBarBackHandler
 
         self.isRTL = isOverride ? context.isRTL : self.isRTL
     }

--- a/packages/sparkling-sdk/ios/Sparkling/Sources/Application/Scheme/SPKContext.swift
+++ b/packages/sparkling-sdk/ios/Sparkling/Sources/Application/Scheme/SPKContext.swift
@@ -27,6 +27,22 @@ public typealias SPKNavigationBarButtonItemBuilder = ((UIViewController & SPKCon
 /// navigation coordinators that retain the container stack.
 public typealias SPKNavigationBarBackHandler = (UIViewController & SPKContainerProtocol) -> Bool
 
+/// Lets a host serialize Sparkling's system interactive-pop gesture with its
+/// own navigation coordinator while preserving UIKit's cancellable transition.
+@objc
+public protocol SPKInteractivePopGestureDelegate: AnyObject {
+    /// Return false to prevent the gesture from beginning.
+    @objc optional func containerShouldBeginInteractivePop(
+        _ container: SPKContainerProtocol
+    ) -> Bool
+
+    /// Called exactly once after an authorized gesture completes or is cancelled.
+    @objc optional func container(
+        _ container: SPKContainerProtocol,
+        didEndInteractivePopCompleted completed: Bool
+    )
+}
+
 /// Enumeration defining the available app theme modes.
 ///
 /// This enum provides theme options for customizing the visual appearance
@@ -118,6 +134,9 @@ open class SPKContext: SPKHybridContext {
     /// Lets an embedding application own its navigation stack without replacing
     /// Sparkling's navigation UI. Returning false preserves the SDK default.
     public var navigationBarBackHandler: SPKNavigationBarBackHandler?
+
+    /// Coordinates the system interactive-pop lifecycle with the embedding host.
+    public weak var interactivePopGestureDelegate: SPKInteractivePopGestureDelegate?
 
     /// Creates a copy of the current SPKContext instance.
     ///
@@ -212,6 +231,12 @@ open class SPKContext: SPKHybridContext {
                 withProp: context.navigationBarBackHandler,
                 to: self.navigationBarBackHandler,
                 isOverride: isOverride) as? SPKNavigationBarBackHandler
+
+        self.interactivePopGestureDelegate =
+            SPKHybridContext.merge(
+                withProp: context.interactivePopGestureDelegate,
+                to: self.interactivePopGestureDelegate,
+                isOverride: isOverride) as? SPKInteractivePopGestureDelegate
 
         self.isRTL = isOverride ? context.isRTL : self.isRTL
     }

--- a/packages/sparkling-sdk/ios/Sparkling/Sources/Application/Scheme/SPKContext.swift
+++ b/packages/sparkling-sdk/ios/Sparkling/Sources/Application/Scheme/SPKContext.swift
@@ -29,6 +29,7 @@ public typealias SPKNavigationBarBackHandler = (UIViewController & SPKContainerP
 
 /// Lets a host serialize Sparkling's system interactive-pop gesture with its
 /// own navigation coordinator while preserving UIKit's cancellable transition.
+@MainActor
 @objc
 public protocol SPKInteractivePopGestureDelegate: AnyObject {
     /// Return false to prevent the gesture from beginning.

--- a/packages/sparkling-sdk/ios/Sparkling/Sources/Service/Base/SPKHybridContext.swift
+++ b/packages/sparkling-sdk/ios/Sparkling/Sources/Service/Base/SPKHybridContext.swift
@@ -143,21 +143,18 @@ open class SPKHybridContext: NSObject, NSCopying {
     /// Merges two dictionaries with optional override behavior.
     ///
     /// - Parameters:
-    ///   - sourDict: The source dictionary to merge from. If nil, returns nil.
-    ///   - targetDict: The target dictionary to merge into. If nil, returns nil.
+    ///   - sourDict: The source dictionary to merge from. Nil is treated as empty.
+    ///   - targetDict: The target dictionary to merge into. Nil is treated as empty.
     ///   - isOverride: If true, existing keys in target will be overwritten.
     ///                 If false, existing keys in target will be preserved.
-    /// - Returns: A new merged dictionary, or nil if either input is nil.
+    /// - Returns: A new merged dictionary. Two nil inputs produce an empty dictionary.
     public static func merge(
         withDict sourDict: [String: Any]?,
         to targetDict: [String: Any]?,
         isOverride: Bool = false
     ) -> [String: Any]? {
-        guard let sourDict = sourDict,
-            let targetDict = targetDict
-        else {
-            return nil
-        }
+        let sourDict = sourDict ?? [:]
+        let targetDict = targetDict ?? [:]
 
         if isEmptyDictionary(targetDict) {
             return sourDict
@@ -203,16 +200,13 @@ open class SPKHybridContext: NSObject, NSCopying {
     /// Merges two arrays by concatenating them.
     ///
     /// - Parameters:
-    ///   - sourceArray: The source array to merge from. If nil, returns nil.
-    ///   - targetArray: The target array to merge into. If nil, returns nil.
-    /// - Returns: A new array containing elements from both arrays, or nil if either input is nil.
+    ///   - sourceArray: The source array to merge from. Nil is treated as empty.
+    ///   - targetArray: The target array to merge into. Nil is treated as empty.
+    /// - Returns: A new array containing elements from both arrays.
     ///            Source array elements are placed before target array elements.
     public static func merge(withArray sourceArray: [Any]?, to targetArray: [Any]?) -> [Any]? {
-        guard let sourceArray = sourceArray,
-            let targetArray = targetArray
-        else {
-            return nil
-        }
+        let sourceArray = sourceArray ?? []
+        let targetArray = targetArray ?? []
         if isEmptyArray(sourceArray) {
             return targetArray
         }
@@ -322,7 +316,8 @@ open class SPKHybridContext: NSObject, NSCopying {
 
         self.lynxModule = Self.merge(
             withDict: context.lynxModule,
-            to: self.lynxModule)
+            to: self.lynxModule,
+            isOverride: isOverride)
 
         self.customUIElements = Self.merge(
             withArray: context.customUIElements,

--- a/packages/sparkling-sdk/ios/Sparkling/Sources/Service/Base/SPKHybridContext.swift
+++ b/packages/sparkling-sdk/ios/Sparkling/Sources/Service/Base/SPKHybridContext.swift
@@ -147,12 +147,15 @@ open class SPKHybridContext: NSObject, NSCopying {
     ///   - targetDict: The target dictionary to merge into. Nil is treated as empty.
     ///   - isOverride: If true, existing keys in target will be overwritten.
     ///                 If false, existing keys in target will be preserved.
-    /// - Returns: A new merged dictionary. Two nil inputs produce an empty dictionary.
+    /// - Returns: A new merged dictionary, or nil when both inputs are nil.
     public static func merge(
         withDict sourDict: [String: Any]?,
         to targetDict: [String: Any]?,
         isOverride: Bool = false
     ) -> [String: Any]? {
+        guard sourDict != nil || targetDict != nil else {
+            return nil
+        }
         let sourDict = sourDict ?? [:]
         let targetDict = targetDict ?? [:]
 
@@ -202,9 +205,12 @@ open class SPKHybridContext: NSObject, NSCopying {
     /// - Parameters:
     ///   - sourceArray: The source array to merge from. Nil is treated as empty.
     ///   - targetArray: The target array to merge into. Nil is treated as empty.
-    /// - Returns: A new array containing elements from both arrays.
+    /// - Returns: A new array containing elements from both arrays, or nil when both inputs are nil.
     ///            Source array elements are placed before target array elements.
     public static func merge(withArray sourceArray: [Any]?, to targetArray: [Any]?) -> [Any]? {
+        guard sourceArray != nil || targetArray != nil else {
+            return nil
+        }
         let sourceArray = sourceArray ?? []
         let targetArray = targetArray ?? []
         if isEmptyArray(sourceArray) {

--- a/packages/sparkling-sdk/ios/Sparkling/Sources/Service/Base/SPKHybridSchemeBuilder.swift
+++ b/packages/sparkling-sdk/ios/Sparkling/Sources/Service/Base/SPKHybridSchemeBuilder.swift
@@ -1,0 +1,112 @@
+// Copyright 2026 The Sparkling Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import Foundation
+
+/// A Lynx resource target accepted by the canonical Sparkling page scheme.
+public enum SPKHybridLynxResource: Equatable, Sendable {
+    /// A bundle name or path resolved by Sparkling's template provider.
+    case bundle(String)
+
+    /// An absolute resource URL resolved by Sparkling's resource loader.
+    case url(String)
+
+    fileprivate var queryItem: URLQueryItem {
+        switch self {
+        case .bundle(let bundle):
+            return URLQueryItem(name: "bundle", value: bundle)
+        case .url(let url):
+            return URLQueryItem(name: "url", value: url)
+        }
+    }
+
+    fileprivate var value: String {
+        switch self {
+        case .bundle(let bundle):
+            return bundle
+        case .url(let url):
+            return url
+        }
+    }
+}
+
+/// Errors returned while constructing a canonical Sparkling page scheme.
+public enum SPKHybridSchemeBuilderError: Error, Equatable, Sendable {
+    /// The bundle or URL target is empty.
+    case emptyResource
+
+    /// A URL-style target is not an absolute URL.
+    case invalidResourceURL(String)
+
+    /// An additional item attempts to replace the builder-owned resource target.
+    case reservedQueryItem(String)
+
+    /// Foundation could not represent the requested values as a valid URL.
+    case unableToBuild
+}
+
+extension SPKHybridSchemeBuilderError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .emptyResource:
+            return "The Sparkling Lynx resource must not be empty."
+        case .invalidResourceURL(let value):
+            return "The Sparkling Lynx resource URL must be absolute: '\(value)'."
+        case .reservedQueryItem(let name):
+            return "The '\(name)' query item is owned by the Sparkling scheme builder."
+        case .unableToBuild:
+            return "The canonical Sparkling page scheme could not be built."
+        }
+    }
+}
+
+extension SPKHybridSchemeParam {
+    /// Builds a canonical `hybrid://lynxview_page` URL.
+    ///
+    /// The resource target is always the first query item. The encoded URL preserves
+    /// the order and duplicates of additional query items, while Foundation performs
+    /// exactly one layer of percent encoding. A resolver that exposes query items as
+    /// a dictionary may still apply last-value-wins semantics. Callers cannot provide
+    /// a second `bundle` or `url` target because Sparkling's resolver requires one
+    /// unambiguous resource owner.
+    ///
+    /// - Parameters:
+    ///   - resource: The Lynx bundle or absolute URL to load.
+    ///   - queryItems: Additional page and container configuration.
+    /// - Returns: A canonical URL accepted by `SPKHybridSchemeParam.resolver`.
+    public static func buildLynxPageScheme(
+        resource: SPKHybridLynxResource,
+        queryItems: [URLQueryItem] = []
+    ) throws -> URL {
+        guard !resource.value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw SPKHybridSchemeBuilderError.emptyResource
+        }
+
+        if case .url(let value) = resource {
+            guard let innerURL = URL(string: value), innerURL.scheme?.isEmpty == false else {
+                throw SPKHybridSchemeBuilderError.invalidResourceURL(value)
+            }
+        }
+
+        if let reservedItem = queryItems.first(where: {
+            let name = $0.name.lowercased()
+            return name == "bundle" || name == "url"
+        }) {
+            throw SPKHybridSchemeBuilderError.reservedQueryItem(reservedItem.name)
+        }
+
+        var components = URLComponents()
+        components.scheme = "hybrid"
+        components.host = Self.lynxViewPageScheme
+        components.queryItems = [resource.queryItem] + queryItems
+
+        guard let url = components.url,
+            Self.canResolve(url: url),
+            Self.engineType(withURL: url) == .SPKHybridEngineTypeLynx
+        else {
+            throw SPKHybridSchemeBuilderError.unableToBuild
+        }
+        return url
+    }
+}

--- a/packages/sparkling-sdk/ios/Sparkling/Sources/Service/Base/SPKKitUtils.swift
+++ b/packages/sparkling-sdk/ios/Sparkling/Sources/Service/Base/SPKKitUtils.swift
@@ -43,4 +43,33 @@ open class SPKKitUtils: NSObject {
         }
         return
     }
+
+    /// Adds container defaults below any page-provided global properties.
+    ///
+    /// Existing values always win so stable container metadata cannot replace
+    /// launch or page data. Both supported global-prop representations retain
+    /// their original representation.
+    class func addDefaultGlobalProps(withContext context: SPKHybridContext?, defaultGlobalProps: [String: Any]?) {
+        guard let context = context else {
+            return
+        }
+        let defaults = defaultGlobalProps ?? [:]
+        if context.globalProps == nil {
+            context.globalProps = defaults
+            return
+        }
+
+        if let existing = context.globalProps as? [String: Any] {
+            var merged = defaults
+            merged.merge(existing) { _, pageValue in pageValue }
+            context.globalProps = merged
+            return
+        }
+
+        if let existing = context.globalProps as? LynxTemplateData {
+            let merged = LynxTemplateData(dictionary: defaults)
+            merged?.update(with: existing)
+            context.globalProps = merged
+        }
+    }
 }

--- a/packages/sparkling-sdk/ios/Sparkling/Sources/Service/LynxService/SPKLynxKitUtils.swift
+++ b/packages/sparkling-sdk/ios/Sparkling/Sources/Service/LynxService/SPKLynxKitUtils.swift
@@ -38,15 +38,18 @@ open class SPKLynxKitUtils: SPKKitUtils {
         lynxKitParams.templateProvider = context?.templateProvider
         lynxKitParams.dynamicComponentFetcher = context?.dynamicComponentFetcher
 
-        // Resolve the resource from the outer canonical scheme before consulting
-        // flattened inner query items. A remote resource may legitimately contain
-        // `?bundle=...`; that nested value must never replace the outer `url` target.
-        let outerParams = context?.schemeParams?.originURL?.spk.decodedQueryItems
-        lynxKitParams.sourceUrl =
-            outerParams?.spk.string(forKey: "bundle")
-            ?? outerParams?.spk.string(forKey: "url")
-            ?? extraParams?.spk.string(forKey: "bundle")
-            ?? extraParams?.spk.string(forKey: "url")
+        // Prefer the resolver-owned URL target before consulting flattened
+        // query items. A remote resource may legitimately contain `?bundle=...`;
+        // that nested value must never replace the resolved outer `url` target.
+        let resolvedURL = context?.schemeParams?.url
+        let bundle = extraParams?.spk.string(forKey: "bundle")
+        if !isEmptyString(resolvedURL) {
+            lynxKitParams.sourceUrl = resolvedURL
+        } else if !isEmptyString(bundle) {
+            lynxKitParams.sourceUrl = bundle
+        } else {
+            lynxKitParams.sourceUrl = extraParams?.spk.string(forKey: "url")
+        }
 
         var initialProps = context?.initialData ?? [:]
 

--- a/packages/sparkling-sdk/ios/Sparkling/Sources/Service/LynxService/SPKLynxKitUtils.swift
+++ b/packages/sparkling-sdk/ios/Sparkling/Sources/Service/LynxService/SPKLynxKitUtils.swift
@@ -38,8 +38,15 @@ open class SPKLynxKitUtils: SPKKitUtils {
         lynxKitParams.templateProvider = context?.templateProvider
         lynxKitParams.dynamicComponentFetcher = context?.dynamicComponentFetcher
 
-        // for LynxView, we default use bundle as the resource to load, and use url as fallback.
-        lynxKitParams.sourceUrl = extraParams?.spk.string(forKey: "bundle") ?? extraParams?.spk.string(forKey: "url")
+        // Resolve the resource from the outer canonical scheme before consulting
+        // flattened inner query items. A remote resource may legitimately contain
+        // `?bundle=...`; that nested value must never replace the outer `url` target.
+        let outerParams = context?.schemeParams?.originURL?.spk.decodedQueryItems
+        lynxKitParams.sourceUrl =
+            outerParams?.spk.string(forKey: "bundle")
+            ?? outerParams?.spk.string(forKey: "url")
+            ?? extraParams?.spk.string(forKey: "bundle")
+            ?? extraParams?.spk.string(forKey: "url")
 
         var initialProps = context?.initialData ?? [:]
 

--- a/packages/sparkling-sdk/ios/Sparkling/Sources/Service/Protocols/UI/SPKLoadErrorViewProtocol.swift
+++ b/packages/sparkling-sdk/ios/Sparkling/Sources/Service/Protocols/UI/SPKLoadErrorViewProtocol.swift
@@ -4,8 +4,11 @@
 
 import Foundation
 
-public typealias SPKLoadErrorRefreshBlock = () -> Void
+/// Refreshes a failed container load. Error views must invoke this callback on the main actor.
+public typealias SPKLoadErrorRefreshBlock = @MainActor () -> Void
 
+/// A UIKit error view contract. Conformance and callbacks are isolated to the main actor.
+@MainActor
 @objc
 public protocol SPKLoadErrorViewProtocol {
     /// Registers a callback that the error view may retain and invoke later.

--- a/packages/sparkling-sdk/ios/Sparkling/Sources/Service/Protocols/UI/SPKLoadErrorViewProtocol.swift
+++ b/packages/sparkling-sdk/ios/Sparkling/Sources/Service/Protocols/UI/SPKLoadErrorViewProtocol.swift
@@ -8,7 +8,8 @@ public typealias SPKLoadErrorRefreshBlock = () -> Void
 
 @objc
 public protocol SPKLoadErrorViewProtocol {
-    @objc optional func register(refreshBlock: SPKLoadErrorRefreshBlock)
+    /// Registers a callback that the error view may retain and invoke later.
+    @objc optional func register(refreshBlock: @escaping SPKLoadErrorRefreshBlock)
 
     @objc optional func container(_ contianer: SPKContainerProtocol, didReceiveError error: Error?)
 


### PR DESCRIPTION
## Summary

Add the iOS SDK contracts needed for host applications to integrate Sparkling through its public router and context APIs, while fixing correctness gaps exposed by full-page container integration.

## Contract changes

- Add `SPKHybridSchemeParam.buildLynxPageScheme` for canonical `hybrid://lynxview_page` URLs:
  - supports bundle and absolute remote URL resources;
  - rejects empty, relative-URL, or conflicting `bundle`/`url` inputs;
  - performs one layer of percent encoding and preserves additional query-item order and duplicates.
- Add explicit host navigation ownership:
  - `navigationBarBackHandler` distinguishes host-consumed or intentionally rejected actions from SDK-default fallback;
  - weak, main-actor `SPKInteractivePopGestureDelegate` authorizes UIKit interactive pop and reports exactly one completion or cancellation;
  - host-managed system-pop enablement is temporary and restores the prior gesture state.
- Make failed-view creation and refresh registration main-actor isolated, retain the registered refresh handler, and return the constructed error view.
- Preserve host configuration through context copying and merging:
  - a nil merge operand acts as the identity while two nil operands remain nil;
  - `lynxModule` honors `isOverride`;
  - modules, custom elements, and navigation hooks survive copying.
- Add `SPK_version` as a default below page-owned global props for both dictionaries and `LynxTemplateData`.
- Prefer the resolver-owned resource URL when loading Lynx content, preventing query items inside a remote URL from replacing the outer resource target.

These changes are intentionally more than blanket source-compatible additions: several correct previously lossy or ambiguous runtime behaviors, and the strengthened main-actor annotations may require call-site isolation updates under strict Swift concurrency checking.

## Validation

- `SparklingGoTests`: **322 tests in 20 suites passed**, with no failures.
- Added coverage for canonical scheme construction, navigation ownership and interactive-pop lifecycle, error-view retention, context copy/merge semantics, global-prop precedence, and remote resource ownership.
- Updated the English and Chinese iOS API and scheme documentation.

## Integration note

The first-phase iOS Lynx Explorer integration pins this exact PR head:

`5fa010cd2e669a73651a2e9321f28458ca3f6b2c`

That source override should be advanced or removed only after an official Sparkling release includes this contract, imposes no incompatible version constraints on source-owned Lynx pods, resolves against a local Lynx checkout without mutation, and passes the dependency, Debug/Release build, and runtime ownership matrix.
