### PR TITLE
fix(ios): preserve active interactive pop gesture

### DIFF
--- a/packages/playground/src/pages/main/App.tsx
+++ b/packages/playground/src/pages/main/App.tsx
@@ -66,6 +66,23 @@ const CATEGORIES: Category[] = [
   },
 ]
 
+function availableCategories(): Category[] {
+  const rawCapabilities = ((lynx.__globalProps || {}) as any)
+    ?.sparklingHostCapabilities
+  if (typeof rawCapabilities !== 'string' || rawCapabilities.length === 0) {
+    // Sparkling Go owns all demos when it runs in its standalone host.
+    return CATEGORIES
+  }
+  const capabilities = new Set(
+    rawCapabilities.split(',').map((item: string) => item.trim().toLowerCase()),
+  )
+  return CATEGORIES.filter((category) => {
+    if (category.name === 'Storage') return capabilities.has('storage')
+    if (category.name === 'Media') return capabilities.has('media')
+    return true
+  })
+}
+
 function HomePage(props: { showPage: boolean; topInset: number }) {
   const { resolved } = useTheme()
   const [source, setSource] = useState('')
@@ -73,6 +90,7 @@ function HomePage(props: { showPage: boolean; topInset: number }) {
   const [openResult, setOpenResult] = useState('')
   const [recentUrls, setRecentUrls] = useState<string[]>([])
   const isDark = resolved === 'dark'
+  const categories = availableCategories()
 
   useEffect(() => {
     if (props.showPage) {
@@ -281,7 +299,7 @@ function HomePage(props: { showPage: boolean; topInset: number }) {
         </view>
 
         {/* Demo Categories (merged from Showcase) */}
-        {CATEGORIES.map((category) => (
+        {categories.map((category) => (
           <view key={category.name} className="category-section">
             <view className="category-header">
               <view className="category-icon-circle" style={{ backgroundColor: `${category.color}18` }}>

--- a/packages/sparkling-sdk/ios/Sparkling/Sources/Application/Container/SPKViewController.swift
+++ b/packages/sparkling-sdk/ios/Sparkling/Sources/Application/Container/SPKViewController.swift
@@ -402,10 +402,23 @@ open class SPKViewController: UIViewController, SPKContainerProtocol {
                     ], callback: nil)
             }
             self.notifyHostInteractivePopDidEnd(completed: !context.isCancelled)
+            if context.isCancelled {
+                // The container remains visible after a cancelled pop, so it
+                // must continue owning the gesture that UIKit just finished.
+                self.navigationController?.interactivePopGestureRecognizer?.delegate = self
+                self.navigationController?.interactivePopGestureRecognizer?.isEnabled = true
+            } else {
+                self.restoreInteractivePopGestureOwnership()
+            }
         }
 
-        self.navigationController?.interactivePopGestureRecognizer?.delegate = self.oldDelegate
-        self.navigationController?.interactivePopGestureRecognizer?.isEnabled = self.originControllerPopGestureRecongnizerEnabled
+        // Disabling UIKit's active recognizer here leaves its interactive
+        // transition permanently in flight when the host originally kept the
+        // system gesture disabled. Defer restoration until UIKit reports that
+        // the authorized interaction completed or was cancelled.
+        if !self.hostInteractivePopInFlight {
+            self.restoreInteractivePopGestureOwnership()
+        }
         self.navigationController?.delegate = self.originalNavigationControllerDelegate
         super.viewWillDisappear(animated)
 
@@ -414,6 +427,12 @@ open class SPKViewController: UIViewController, SPKContainerProtocol {
             self.handleViewDidDisappear()
         }
         self.containerLifecycleDelegate?.containerViewWillDisappear?(self)
+    }
+
+    private func restoreInteractivePopGestureOwnership() {
+        self.navigationController?.interactivePopGestureRecognizer?.delegate = self.oldDelegate
+        self.navigationController?.interactivePopGestureRecognizer?.isEnabled =
+            self.originControllerPopGestureRecongnizerEnabled
     }
 
     /// Called when the view has disappeared.

--- a/packages/sparkling-sdk/ios/Sparkling/Sources/Utils/SPKVersion.swift
+++ b/packages/sparkling-sdk/ios/Sparkling/Sources/Utils/SPKVersion.swift
@@ -35,7 +35,7 @@ open class SPKVersion: NSObject {
     ///
     /// - Note: This method returns a static string that should be updated during the build process
     ///   or release workflow to reflect the actual framework version.
-    static func SPKVersion() -> String {
-        return "1.0.0"
+    public static func SPKVersion() -> String {
+        return "2.1.0-rc.12"
     }
 }


### PR DESCRIPTION
## Summary

- defer restoring the host interactive-pop gesture until UIKit resolves the interaction
- keep Sparkling gesture ownership when an interactive pop is cancelled
- restore the embedding host ownership only after a completed pop

## Why

Disabling an active interactive-pop recognizer in viewWillDisappear can leave UIKit transition coordination permanently in flight when the embedding host originally kept the system gesture disabled.

## Test

- Integrated Debug iOS Simulator build in Lynx Explorer
- RouteCoordinatorTests and SparklingContainerLauncherTests (55 tests)

## Stack

- Base: #113
