### PR TITLE
ci: decouple the npm version from Node upgrades

### DIFF
--- a/.github/actions/preflight-registry-auth/action.yml
+++ b/.github/actions/preflight-registry-auth/action.yml
@@ -35,14 +35,8 @@ runs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '22.21.1'
+        node-version: '22.22.2'
         registry-url: 'https://registry.npmjs.org'
-
-    - name: Ensure latest npm
-      shell: bash
-      run: |
-        npm install -g npm@latest
-        npm --version
 
     - name: Verify npm registry connectivity
       shell: bash

--- a/.github/actions/verify-template-android/action.yml
+++ b/.github/actions/verify-template-android/action.yml
@@ -11,7 +11,7 @@ inputs:
   node_version:
     description: Node.js version
     required: false
-    default: '22.21.1'
+    default: '22.22.2'
   pnpm_version:
     description: pnpm version
     required: false

--- a/.github/actions/verify-template-ios/action.yml
+++ b/.github/actions/verify-template-ios/action.yml
@@ -11,7 +11,7 @@ inputs:
   node_version:
     description: Node.js version
     required: false
-    default: '22.21.1'
+    default: '22.22.2'
   pnpm_version:
     description: pnpm version
     required: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 22.22.2
           cache: pnpm
 
       - name: Install dependencies
@@ -172,7 +172,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 22.22.2
           cache: pnpm
 
       - name: Install dependencies
@@ -216,7 +216,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 22.22.2
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  NODE_VERSION: '22.21.1'
+  NODE_VERSION: '22.22.2'
 
 jobs:
   build:

--- a/.github/workflows/publish-release-resume.yml
+++ b/.github/workflows/publish-release-resume.yml
@@ -53,8 +53,12 @@ permissions:
   id-token: write
 
 env:
-  NODE_VERSION: '22.21.1'
+  NODE_VERSION: '22.22.2'
   PNPM_VERSION: '10.26.0'
+  # pnpm 10 delegates the Trusted Publishing OIDC exchange to the npm CLI, which
+  # needs npm >= 11.5.1. Pinned to the 11.x line on purpose: npm 12 requires an
+  # exact Node patch floor, so tracking npm@latest would force Node bumps on us.
+  NPM_VERSION: '11.19.0'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.version }}
@@ -158,9 +162,8 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Ensure latest npm
-        run: |
-          npm install -g npm@latest
+      - name: Pin npm (>= 11.5.1 required for Trusted Publishing)
+        run: npm install -g "npm@${NPM_VERSION}"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
@@ -304,8 +307,8 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Ensure latest npm
-        run: npm install -g npm@latest
+      - name: Pin npm (>= 11.5.1 required for Trusted Publishing)
+        run: npm install -g "npm@${NPM_VERSION}"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -17,8 +17,12 @@ permissions:
   id-token: write
 
 env:
-  NODE_VERSION: '22.21.1'
+  NODE_VERSION: '22.22.2'
   PNPM_VERSION: '10.26.0'
+  # pnpm 10 delegates the Trusted Publishing OIDC exchange to the npm CLI, which
+  # needs npm >= 11.5.1. Pinned to the 11.x line on purpose: npm 12 requires an
+  # exact Node patch floor, so tracking npm@latest would force Node bumps on us.
+  NPM_VERSION: '11.19.0'
   NPM_REGISTRY_URL: 'https://registry.npmjs.org'
 
 concurrency:
@@ -148,10 +152,10 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: ${{ env.NPM_REGISTRY_URL }}
 
-      - name: Ensure latest npm (>= 11.5.1 required for Trusted Publishing)
+      - name: Pin npm (>= 11.5.1 required for Trusted Publishing)
         run: |
-          echo "📦 Upgrading npm for Trusted Publishing support..."
-          npm install -g npm@latest
+          echo "📦 Installing npm@${NPM_VERSION} for Trusted Publishing support..."
+          npm install -g "npm@${NPM_VERSION}"
           echo "✅ npm version: $(npm --version)"
 
       - name: Setup pnpm
@@ -407,10 +411,10 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: ${{ env.NPM_REGISTRY_URL }}
 
-      - name: Ensure latest npm (>= 11.5.1 required for Trusted Publishing)
+      - name: Pin npm (>= 11.5.1 required for Trusted Publishing)
         run: |
-          echo "📦 Upgrading npm for Trusted Publishing support..."
-          npm install -g npm@latest
+          echo "📦 Installing npm@${NPM_VERSION} for Trusted Publishing support..."
+          npm install -g "npm@${NPM_VERSION}"
           echo "✅ npm version: $(npm --version)"
 
       - name: Setup pnpm


### PR DESCRIPTION
Installing npm@latest let npm's own engine requirements drive our Node version: npm 12 requires Node ^22.22.2, which is what pushed the runners off 22.21.1. Pin npm to the 11.x line (engines: ^20.17.0 || >=22.9.0) through a shared NPM_VERSION so it stays above the 11.5.1 floor that pnpm 10 needs for Trusted Publishing, without dragging Node along on every npm major.

Also drop the npm upgrade from the registry preflight action, which only runs npm ping and works fine with the npm bundled with Node.

