### PR TITLE
[Feature][Android] Add pre-load Lynx view lifecycle

### DIFF
--- a/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/SparklingContext.kt
+++ b/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/SparklingContext.kt
@@ -7,10 +7,18 @@ import android.content.Context
 import android.util.Size
 import android.view.View
 import androidx.appcompat.widget.Toolbar
+import com.lynx.tasm.LynxView
 import com.tiktok.sparkling.hybridkit.HybridContext
 import com.tiktok.sparkling.hybridkit.base.HybridKitError
 import com.tiktok.sparkling.hybridkit.base.HybridKitType
 import com.tiktok.sparkling.hybridkit.base.IKitView
+
+/**
+ * Observes a created Lynx view after Sparkling initializes its bridge and before template loading.
+ */
+fun interface SparklingLynxViewCreatedListener {
+    fun onCreated(lynxView: LynxView)
+}
 
 interface SparklingUIProvider {
     fun getLoadingView(context: Context): View
@@ -94,4 +102,5 @@ interface SparklingLifecycleDelegate {
 class SparklingContext : HybridContext() {
     var sparklingUIProvider: SparklingUIProvider? = null
     var lifecycleDelegate: SparklingLifecycleDelegate? = null
+    var lynxViewCreatedListener: SparklingLynxViewCreatedListener? = null
 }

--- a/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/hybridkit/lynx/HybridLynxKit.kt
+++ b/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/hybridkit/lynx/HybridLynxKit.kt
@@ -14,6 +14,7 @@ import com.lynx.tasm.LynxViewBuilder
 import com.lynx.tasm.behavior.Behavior
 import com.lynx.tasm.behavior.BehaviorBundle
 import com.lynx.tasm.service.LynxServiceCenter
+import com.tiktok.sparkling.SparklingContext
 import com.tiktok.sparkling.hybridkit.HybridCommon
 import com.tiktok.sparkling.hybridkit.HybridContext
 import com.tiktok.sparkling.hybridkit.base.IHybridKitLifeCycle
@@ -106,6 +107,7 @@ object HybridLynxKit {
         }
         val bridge = SparklingBridge()
         bridge.registerLynxModule(viewBuilder, hybridContext.containerId)
+        val sparklingContext = hybridContext as? SparklingContext
         val lynxView =
             SimpleLynxKitView(context, hybridContext, viewBuilder, kitInitParams, lifeCycle)
         lynxViewRef = lynxView
@@ -115,6 +117,7 @@ object HybridLynxKit {
             BridgeProtocolConstants.BRIDGE_LYNX_PROTOCOL,
         )
         hybridContext.bridge = bridge
+        sparklingContext?.lynxViewCreatedListener?.onCreated(lynxView)
 
         lifeCycle?.onPostKitCreated(lynxView)
         return lynxView

--- a/packages/sparkling-sdk/android/sparkling/src/test/java/com/tiktok/sparkling/hybridkit/HybridKitTest.kt
+++ b/packages/sparkling-sdk/android/sparkling/src/test/java/com/tiktok/sparkling/hybridkit/HybridKitTest.kt
@@ -10,11 +10,15 @@ import android.content.res.Resources
 import android.view.WindowManager
 import android.view.Display
 import android.view.accessibility.AccessibilityManager
+import com.lynx.tasm.LynxView
+import com.tiktok.sparkling.SparklingContext
+import com.tiktok.sparkling.SparklingLynxViewCreatedListener
 import com.tiktok.sparkling.hybridkit.HybridContext
 import com.tiktok.sparkling.hybridkit.HybridKit
 import com.tiktok.sparkling.hybridkit.HybridCommon
 import com.tiktok.sparkling.hybridkit.HybridEnvironment
 import com.tiktok.sparkling.hybridkit.KitViewManager
+import com.tiktok.sparkling.hybridkit.base.IHybridKitLifeCycle
 import com.tiktok.sparkling.hybridkit.base.HybridKitType
 import com.tiktok.sparkling.hybridkit.base.HybridLoadSession
 import com.tiktok.sparkling.hybridkit.base.Theme
@@ -117,6 +121,62 @@ class HybridKitTest {
         val result = HybridKit.createKitView(scheme, param, mockContext)
 
         assertNull(result)
+    }
+
+    @Test
+    fun testLynxViewCreatedListenerRunsAfterBridgeBeforePostCreate() {
+        val events = mutableListOf<String>()
+        var bridgeAvailable = false
+        var createdView: LynxView? = null
+        val scheme =
+            HybridSchemeParam(
+                engineType = HybridKitType.LYNX,
+                bundle = "https://example.com/main.lynx.bundle",
+            )
+        val sparklingContext =
+            SparklingContext().apply {
+                hybridSchemeParam = scheme
+                lynxViewCreatedListener =
+                    SparklingLynxViewCreatedListener { lynxView ->
+                        events += "VIEW_CREATED"
+                        createdView = lynxView
+                        bridgeAvailable = bridge != null
+                    }
+            }
+        val lifeCycle =
+            object : IHybridKitLifeCycle() {
+                override fun onPostKitCreated(view: com.tiktok.sparkling.hybridkit.base.IKitView) {
+                    events += "POST_KIT_CREATED"
+                }
+            }
+
+        val result = HybridKit.createKitView(scheme, sparklingContext, mockContext, lifeCycle)
+
+        assertEquals(
+            listOf(
+                "VIEW_CREATED",
+                "POST_KIT_CREATED",
+            ),
+            events,
+        )
+        assertTrue(bridgeAvailable)
+        assertSame(result, createdView)
+    }
+
+    @Test
+    fun testLynxViewCreatedListenerIsDisabledByDefault() {
+        val scheme =
+            HybridSchemeParam(
+                engineType = HybridKitType.LYNX,
+                bundle = "https://example.com/main.lynx.bundle",
+            )
+        val sparklingContext =
+            SparklingContext().apply {
+                hybridSchemeParam = scheme
+            }
+
+        assertNull(sparklingContext.lynxViewCreatedListener)
+        assertNotNull(HybridKit.createKitView(scheme, sparklingContext, mockContext))
     }
 }
 


### PR DESCRIPTION
## Summary

Add a Java-friendly pre-load Lynx view lifecycle seam for Android hosts.

This is a deliberately narrow foundation layer. It does not expose `LynxViewBuilder` or add thread, viewport, density, resource-fetcher, module, or background-runtime behavior.

## Related issues

Standalone host-integration enhancement. Follow-up PRs will implement and validate individual capabilities directly in `HybridLynxKit`; density will use a separate shared-process policy.

## Changes

- Add `SparklingLynxViewCreatedListener` to `SparklingContext`.
- Invoke it after Sparkling initializes its bridge and before `onPostKitCreated` or template loading.
- Preserve existing behavior when no listener is installed.
- Test callback ordering, bridge availability, created-view identity, and the default unset path.

## How to test

- `cd packages/playground/android && ./gradlew :sparkling:testDebugUnitTest --tests com.tiktok.sparkling.hybridkit.HybridKitTest --no-daemon`
- `PATH=/tmp/sparkling-ktlint-bin:$PATH scripts/lint.sh kotlin`

Both checks passed on the Android devbox using ktlint 1.8.0, matching CI.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I explained why this is standalone.
- [x] I ran relevant checks.
- [x] I updated API documentation in code.
- [x] I added/updated tests.


## Expanded durable device validation

The checked-in SG1 + Lynx Sandbox matrix in #131 now validates exact commit `df875a87541d587ab8aa84a86600c0610f9e44c7` with **10/10 PASS** on `aries_10` (Android 10 / API 29). Added runtime coverage includes: the pre-load listener observing a ready bridge before template fetch; the global per-page fetcher factory; real first-screen rendering for `ALL_ON_UI`, `MOST_ON_TASM`, `PART_ON_LAYOUT`, and safe `MULTI_THREADS`; and full-page fixed-viewport + `MULTI_THREADS` rejection before Activity launch or transfer-station save. The runner requires a clean exact HEAD and fails closed unless Sandbox release confirms the leased serial. Evidence: `/tmp/sparkling-android-device-acceptance-df875a8`; archive SHA-256 `712a3b83dbd78eabeae9afc0766b5b191cee0bff10e515967b3ae9f46c4feb98`.
