### PR TITLE
[Feature][Android] Add shared-process Lynx density policy

### DIFF
--- a/docs/en/apis/sparkling-sdk-android.md
+++ b/docs/en/apis/sparkling-sdk-android.md
@@ -20,6 +20,7 @@ HybridKit.init(this)
 val baseInfoConfig = BaseInfoConfig(isDebug = BuildConfig.DEBUG)
 val lynxConfig = SparklingLynxConfig.build(this) {
   // optional: add global Lynx behaviors/modules, template provider, etc.
+  // setSharedProcessDensityOverride(2.0f)
 }
 val hybridConfig = SparklingHybridConfig.build(baseInfoConfig) {
   setLynxConfig(lynxConfig)
@@ -28,6 +29,19 @@ val hybridConfig = SparklingHybridConfig.build(baseInfoConfig) {
 HybridKit.setHybridConfig(hybridConfig, this)
 HybridKit.initLynxKit()
 ```
+
+### Shared-process Lynx density
+
+`setSharedProcessDensityOverride(density)` sets one logical density for every Sparkling
+`LynxView` created in the host process. The value must be finite and greater than zero. When it is
+unset, Sparkling leaves Lynx density unset and Lynx uses its default screen-density behavior.
+
+Lynx currently treats a density override as process-wide state. If the host enables this option,
+**every non-Sparkling `LynxView` in the same process must also be constructed with the same
+density**. Do not derive or change this value per container or per URL.
+
+This API provides a host-wide density policy; it does not claim arbitrary legacy URL density
+compatibility.
 
 ## Sparkling
 

--- a/docs/zh/apis/sparkling-sdk-android.md
+++ b/docs/zh/apis/sparkling-sdk-android.md
@@ -20,6 +20,7 @@ HybridKit.init(this)
 val baseInfoConfig = BaseInfoConfig(isDebug = BuildConfig.DEBUG)
 val lynxConfig = SparklingLynxConfig.build(this) {
   // 可选：添加全局 Lynx 行为/模块、模板提供者等
+  // setSharedProcessDensityOverride(2.0f)
 }
 val hybridConfig = SparklingHybridConfig.build(baseInfoConfig) {
   setLynxConfig(lynxConfig)
@@ -28,6 +29,19 @@ val hybridConfig = SparklingHybridConfig.build(baseInfoConfig) {
 HybridKit.setHybridConfig(hybridConfig, this)
 HybridKit.initLynxKit()
 ```
+
+### Lynx 全进程 density
+
+`setSharedProcessDensityOverride(density)` 为宿主进程内 Sparkling 创建的所有 `LynxView`
+设置同一个逻辑 density。该值必须是有限数且大于零。未设置时，Sparkling 不覆盖 Lynx
+density，由 Lynx 沿用默认的屏幕 density 行为。
+
+Lynx 当前将 density override 视为进程级状态。如果宿主启用该选项，**同一进程内所有非
+Sparkling 创建的 `LynxView` 也必须使用完全相同的 density 构造**。不要按容器或 URL
+计算或修改该值。
+
+该 API 只提供宿主级统一 density 策略，不代表可以兼容任意 Legacy URL 中的 density
+语义。
 
 ## Sparkling
 

--- a/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/hybridkit/config/SparklingLynxConfig.kt
+++ b/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/hybridkit/config/SparklingLynxConfig.kt
@@ -19,6 +19,7 @@ class SparklingLynxConfig private constructor(
     val globalBehaviors: MutableList<Behavior>,
     val globalModules: MutableMap<String, SparklingLynxModuleWrapper>,
     val additionInit: LynxEnv.() -> Unit,
+    val sharedProcessDensityOverride: Float?,
     val logLevel: Int = LLog.INFO,
 ) : ILynxConfig {
     companion object {
@@ -37,6 +38,7 @@ class SparklingLynxConfig private constructor(
         private val globalBehaviors = mutableListOf<Behavior>()
         private val globalModules = mutableMapOf<String, SparklingLynxModuleWrapper>()
         private var additionInit: LynxEnv.() -> Unit = {}
+        private var sharedProcessDensityOverride: Float? = null
 
         fun setCheckPropsSetter(checkPropsSetter: Boolean) {
             isCheckPropsSetter = checkPropsSetter
@@ -62,6 +64,19 @@ class SparklingLynxConfig private constructor(
             this.additionInit = additionInit
         }
 
+        /**
+         * Overrides Lynx density for the entire host process.
+         *
+         * Lynx requires every LynxView in a process to use the same override. Hosts that enable
+         * this must configure non-Sparkling LynxViews with the same density.
+         */
+        fun setSharedProcessDensityOverride(density: Float) {
+            require(density.isFinite() && density > 0f) {
+                "Shared-process Lynx density must be finite and greater than 0."
+            }
+            sharedProcessDensityOverride = density
+        }
+
         fun build() =
             SparklingLynxConfig(
                 context,
@@ -71,6 +86,7 @@ class SparklingLynxConfig private constructor(
                 globalBehaviors,
                 globalModules,
                 additionInit,
+                sharedProcessDensityOverride,
             )
     }
 }

--- a/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/hybridkit/lynx/HybridLynxKit.kt
+++ b/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/hybridkit/lynx/HybridLynxKit.kt
@@ -98,7 +98,7 @@ object HybridLynxKit {
             kitInitParams.loadUri = hybridContext.resolveFullScheme()?.toUri()
         }
 
-        val viewBuilder = LynxViewBuilder()
+        val viewBuilder = createLynxViewBuilder(lynxConfig)
         (hybridContext as? SparklingContext)?.resolveLynxViewport()?.let { viewport ->
             viewBuilder.applyLynxViewport(viewport)
         }
@@ -127,4 +127,9 @@ object HybridLynxKit {
         lifeCycle?.onPostKitCreated(lynxView)
         return lynxView
     }
+
+    internal fun createLynxViewBuilder(lynxConfig: SparklingLynxConfig?): LynxViewBuilder =
+        LynxViewBuilder().apply {
+            lynxConfig?.sharedProcessDensityOverride?.let(::setDensity)
+        }
 }

--- a/packages/sparkling-sdk/android/sparkling/src/test/java/com/tiktok/sparkling/hybridkit/config/HybridConfigTest.kt
+++ b/packages/sparkling-sdk/android/sparkling/src/test/java/com/tiktok/sparkling/hybridkit/config/HybridConfigTest.kt
@@ -107,6 +107,7 @@ class HybridConfigTest {
         assertTrue(empty.globalBehaviors.isEmpty())
         assertTrue(empty.globalModules.isEmpty())
         assertNotNull(empty.additionInit)
+        assertNull(empty.sharedProcessDensityOverride)
 
         val moduleWrapper = mockk<SparklingLynxModuleWrapper>(relaxed = true)
         var initCalled = false
@@ -125,5 +126,42 @@ class HybridConfigTest {
         // exercise additionInit lambda
         cfg.additionInit.invoke(mockk<LynxEnv>(relaxed = true))
         assertTrue(initCalled)
+    }
+
+    @Test
+    fun sparklingLynxConfigBuilderPropagatesSharedProcessDensityOverride() {
+        val app = mockk<Application>(relaxed = true)
+
+        val cfg =
+            SparklingLynxConfig.build(app) {
+                setSharedProcessDensityOverride(2.75f)
+            }
+
+        assertEquals(2.75f, cfg.sharedProcessDensityOverride)
+    }
+
+    @Test
+    fun sparklingLynxConfigBuilderRejectsInvalidSharedProcessDensityOverride() {
+        val app = mockk<Application>(relaxed = true)
+        val invalidDensities =
+            listOf(
+                0f,
+                -1f,
+                Float.NaN,
+                Float.POSITIVE_INFINITY,
+                Float.NEGATIVE_INFINITY,
+            )
+
+        invalidDensities.forEach { density ->
+            val error =
+                runCatching {
+                    SparklingLynxConfig.Builder(app).setSharedProcessDensityOverride(density)
+                }.exceptionOrNull()
+
+            assertTrue(
+                "Expected density $density to be rejected",
+                error is IllegalArgumentException,
+            )
+        }
     }
 }

--- a/packages/sparkling-sdk/android/sparkling/src/test/java/com/tiktok/sparkling/hybridkit/lynx/HybridLynxKitDensityTest.kt
+++ b/packages/sparkling-sdk/android/sparkling/src/test/java/com/tiktok/sparkling/hybridkit/lynx/HybridLynxKitDensityTest.kt
@@ -1,0 +1,76 @@
+// Copyright (c) 2022 TikTok Pte. Ltd.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+package com.tiktok.sparkling.hybridkit.lynx
+
+import android.app.Application
+import com.lynx.tasm.LynxViewBuilder
+import com.tiktok.sparkling.SparklingContext
+import com.tiktok.sparkling.hybridkit.HybridContext
+import com.tiktok.sparkling.hybridkit.config.SparklingLynxConfig
+import com.tiktok.sparkling.hybridkit.scheme.HybridSchemeParam
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class HybridLynxKitDensityTest {
+    @Test
+    fun defaultConfigLeavesEveryLynxViewBuilderDensityUnset() {
+        val config = SparklingLynxConfig.Builder(mockk<Application>(relaxed = true)).build()
+
+        val builders =
+            listOf(
+                HybridLynxKit.createLynxViewBuilder(config),
+                HybridLynxKit.createLynxViewBuilder(config),
+            )
+
+        builders.forEach { builder ->
+            assertNull(builder.density)
+        }
+    }
+
+    @Test
+    fun sharedProcessDensityOverrideIsAppliedToEveryLynxViewBuilder() {
+        val config =
+            SparklingLynxConfig.build(mockk<Application>(relaxed = true)) {
+                setSharedProcessDensityOverride(3.25f)
+            }
+
+        val builders =
+            listOf(
+                HybridLynxKit.createLynxViewBuilder(config),
+                HybridLynxKit.createLynxViewBuilder(config),
+            )
+
+        builders.forEach { builder ->
+            assertEquals(3.25f, builder.density)
+        }
+    }
+
+    @Test
+    fun containerConfigurationDoesNotExposeDensityOverride() {
+        val forbiddenTypes =
+            listOf(
+                SparklingContext::class.java,
+                HybridContext::class.java,
+                LynxKitInitParams::class.java,
+                HybridSchemeParam::class.java,
+            )
+
+        forbiddenTypes.forEach { type ->
+            val memberNames =
+                (type.declaredFields.map { it.name } + type.declaredMethods.map { it.name })
+                    .map(String::lowercase)
+
+            assertFalse(
+                "${type.simpleName} must not expose a per-container density API",
+                memberNames.any { it.contains("density") },
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add an explicitly shared-process Lynx density policy for Android Sparkling hosts.

This is the third layer of the Android compatibility stack and depends on #120. It intentionally does **not** expose per-container or per-URL density because Lynx currently stores overridden density in process-wide metrics.

## Related issues

Standalone host policy needed to make density behavior explicit while avoiding a false per-page compatibility promise.

## Changes

- Add `setSharedProcessDensityOverride` to `SparklingLynxConfig.Builder`.
- Validate that the configured value is finite and greater than zero.
- Apply the same value to every Sparkling LynxView builder before construction.
- Keep context, init-param, and scheme APIs density-free.
- Document the obligation for non-Sparkling LynxViews in the same process to use the same density.
- Test validation, default-unset behavior, propagation to multiple builders, and absence of per-container density APIs.

## How to test

- `cd packages/playground/android && ./gradlew :sparkling:testDebugUnitTest --tests com.tiktok.sparkling.hybridkit.config.HybridConfigTest --tests com.tiktok.sparkling.hybridkit.lynx.HybridLynxKitDensityTest --no-daemon`
- `PATH=/tmp/sparkling-ktlint-bin:$PATH scripts/lint.sh kotlin`

Device validation will verify two pages share the configured pixel ratio before this PR is considered complete.

## Stack

- #119 pre-load Lynx view lifecycle
- #120 fixed viewport
- **This PR:** shared-process density policy

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I explained why this is standalone.
- [x] I ran relevant checks.
- [x] I updated docs.
- [x] I added tests.


## Device validation complete

The durable SG1 + Lynx Sandbox acceptance matrix is now available in #131. Exact validated commit: `8a2b3ea99eaa342e2f1ebfe716aefbb44f411fbb`. On a fresh `aries_10` device (Android 10 / API 29), all 9 tests passed, including real first-screen rendering, fixed `320x480`, shared density `3.25` across two independent Lynx views, `PART_ON_LAYOUT`, typed template fetch invocation, orientation, retry recovery, and unsafe configuration rejection. The runner dynamically leases/releases the device and archives logs/screenshots/hashes. Evidence archive on SG1: `/tmp/sparkling-android-device-acceptance-8a2b3ea.tar.gz` (SHA-256 `09acd64b4b63988b61e7f4f2ff11f3f7b4b4770bd3ef74a973db6dda0c9e242c`).


## Expanded durable device validation

The checked-in SG1 + Lynx Sandbox matrix in #131 now validates exact commit `df875a87541d587ab8aa84a86600c0610f9e44c7` with **10/10 PASS** on `aries_10` (Android 10 / API 29). Added runtime coverage includes: the pre-load listener observing a ready bridge before template fetch; the global per-page fetcher factory; real first-screen rendering for `ALL_ON_UI`, `MOST_ON_TASM`, `PART_ON_LAYOUT`, and safe `MULTI_THREADS`; and full-page fixed-viewport + `MULTI_THREADS` rejection before Activity launch or transfer-station save. The runner requires a clean exact HEAD and fails closed unless Sandbox release confirms the leased serial. Evidence: `/tmp/sparkling-android-device-acceptance-df875a8`; archive SHA-256 `712a3b83dbd78eabeae9afc0766b5b191cee0bff10e515967b3ae9f46c4feb98`.
