### PR TITLE
[Feature][Android] Add page resource fetchers

### DIFF
--- a/docs/en/apis/sparkling-sdk-android.md
+++ b/docs/en/apis/sparkling-sdk-android.md
@@ -22,6 +22,13 @@ val lynxConfig = SparklingLynxConfig.build(this) {
   // optional: add global Lynx behaviors/modules, template provider, etc.
   // setSharedProcessDensityOverride(2.0f)
   setDefaultThreadStrategy(SparklingThreadStrategy.MULTI_THREADS)
+  setResourceFetcherFactory { sparklingContext ->
+    SparklingResourceFetcherConfig.builder()
+      .setGenericResourceFetcher(createGenericFetcher(sparklingContext))
+      .setMediaResourceFetcher(createMediaFetcher(sparklingContext))
+      .setTemplateResourceFetcher(createTemplateFetcher(sparklingContext))
+      .build()
+  }
 }
 val hybridConfig = SparklingHybridConfig.build(baseInfoConfig) {
   setLynxConfig(lynxConfig)
@@ -83,6 +90,32 @@ Configuration object passed to both container types.
 | `hybridSchemeParam` | Parsed scheme parameters (auto-populated from `scheme`). |
 | `lynxViewport` | Optional `SparklingLynxViewport(widthPx, heightPx)` fixed viewport in physical pixels. Programmatic configuration overrides parsed scheme dimensions. |
 | `containerId` | Unique container identifier (auto-generated). |
+| `resourceFetcherConfig` | Optional per-page typed resource fetchers. Overrides the global factory. |
+
+## Typed resource fetchers
+
+Use `SparklingResourceFetcherConfig` to provide Lynx generic, media, and
+template resource fetchers without accessing Sparkling's internal
+`LynxViewBuilder`. Set it on `SparklingContext` for one page, or configure a
+`SparklingResourceFetcherFactory` on `SparklingLynxConfig` to create fetchers
+for every page.
+
+```java
+SparklingResourceFetcherConfig fetchers =
+    SparklingResourceFetcherConfig.builder()
+        .setGenericResourceFetcher(genericFetcher)
+        .setMediaResourceFetcher(mediaFetcher)
+        .setTemplateResourceFetcher(templateFetcher)
+        .build();
+sparklingContext.setResourceFetcherConfig(fetchers);
+```
+
+The per-page config takes precedence over the global factory. Sparkling
+automatically enables Lynx generic resource fetching when a generic fetcher is
+configured. A typed template fetcher is wrapped so Sparkling's resource
+lifecycle receives one start and at most one finish event for both template
+and SSR requests. If no typed template fetcher is configured, Sparkling keeps
+using the existing `SimpleLynxTemplateProvider` path.
 
 For advanced hosts that already provide `LynxKitInitParams`, set its `lynxViewport` property. Init
 params take precedence over `SparklingContext.lynxViewport`, which takes precedence over canonical

--- a/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/SparklingContext.kt
+++ b/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/SparklingContext.kt
@@ -105,4 +105,5 @@ class SparklingContext : HybridContext() {
     var lynxViewCreatedListener: SparklingLynxViewCreatedListener? = null
     var lynxViewport: SparklingLynxViewport? = null
     var threadStrategy: SparklingThreadStrategy? = null
+    var resourceFetcherConfig: SparklingResourceFetcherConfig? = null
 }

--- a/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/SparklingResourceFetcherConfig.kt
+++ b/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/SparklingResourceFetcherConfig.kt
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 TikTok Pte. Ltd.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+package com.tiktok.sparkling
+
+import com.lynx.tasm.resourceprovider.generic.LynxGenericResourceFetcher
+import com.lynx.tasm.resourceprovider.media.LynxMediaResourceFetcher
+import com.lynx.tasm.resourceprovider.template.LynxTemplateResourceFetcher
+
+/**
+ * Typed Lynx resource fetchers used by one Sparkling page.
+ */
+class SparklingResourceFetcherConfig private constructor(
+    val genericResourceFetcher: LynxGenericResourceFetcher?,
+    val mediaResourceFetcher: LynxMediaResourceFetcher?,
+    val templateResourceFetcher: LynxTemplateResourceFetcher?,
+) {
+    companion object {
+        @JvmStatic
+        fun builder(): Builder = Builder()
+    }
+
+    class Builder {
+        private var genericResourceFetcher: LynxGenericResourceFetcher? = null
+        private var mediaResourceFetcher: LynxMediaResourceFetcher? = null
+        private var templateResourceFetcher: LynxTemplateResourceFetcher? = null
+
+        fun setGenericResourceFetcher(fetcher: LynxGenericResourceFetcher?): Builder =
+            apply {
+                genericResourceFetcher = fetcher
+            }
+
+        fun setMediaResourceFetcher(fetcher: LynxMediaResourceFetcher?): Builder =
+            apply {
+                mediaResourceFetcher = fetcher
+            }
+
+        fun setTemplateResourceFetcher(fetcher: LynxTemplateResourceFetcher?): Builder =
+            apply {
+                templateResourceFetcher = fetcher
+            }
+
+        fun build(): SparklingResourceFetcherConfig =
+            SparklingResourceFetcherConfig(
+                genericResourceFetcher,
+                mediaResourceFetcher,
+                templateResourceFetcher,
+            )
+    }
+}
+
+/**
+ * Creates typed resource fetchers for a Sparkling page.
+ */
+fun interface SparklingResourceFetcherFactory {
+    fun create(sparklingContext: SparklingContext): SparklingResourceFetcherConfig?
+}

--- a/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/hybridkit/config/SparklingLynxConfig.kt
+++ b/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/hybridkit/config/SparklingLynxConfig.kt
@@ -9,6 +9,7 @@ import com.lynx.tasm.LynxEnv
 import com.lynx.tasm.base.LLog
 import com.lynx.tasm.behavior.Behavior
 import com.lynx.tasm.provider.AbsTemplateProvider
+import com.tiktok.sparkling.SparklingResourceFetcherFactory
 import com.tiktok.sparkling.SparklingThreadStrategy
 import com.tiktok.sparkling.hybridkit.lynx.SparklingLynxModuleWrapper
 
@@ -17,6 +18,7 @@ class SparklingLynxConfig private constructor(
     val isCheckPropsSetter: Boolean,
     val libraryLoader: INativeLibraryLoader?,
     val templateProvider: AbsTemplateProvider?,
+    val resourceFetcherFactory: SparklingResourceFetcherFactory?,
     val globalBehaviors: MutableList<Behavior>,
     val globalModules: MutableMap<String, SparklingLynxModuleWrapper>,
     val additionInit: LynxEnv.() -> Unit,
@@ -37,6 +39,7 @@ class SparklingLynxConfig private constructor(
         private var isCheckPropsSetter = true
         private var libraryLoader: INativeLibraryLoader? = null
         private var templateProvider: AbsTemplateProvider? = null
+        private var resourceFetcherFactory: SparklingResourceFetcherFactory? = null
         private val globalBehaviors = mutableListOf<Behavior>()
         private val globalModules = mutableMapOf<String, SparklingLynxModuleWrapper>()
         private var additionInit: LynxEnv.() -> Unit = {}
@@ -53,6 +56,10 @@ class SparklingLynxConfig private constructor(
 
         fun setTemplateProvider(templateProvider: AbsTemplateProvider?) {
             this.templateProvider = templateProvider
+        }
+
+        fun setResourceFetcherFactory(factory: SparklingResourceFetcherFactory?) {
+            resourceFetcherFactory = factory
         }
 
         fun addBehaviors(behaviors: List<Behavior>) {
@@ -90,6 +97,7 @@ class SparklingLynxConfig private constructor(
                 isCheckPropsSetter,
                 libraryLoader,
                 templateProvider,
+                resourceFetcherFactory,
                 globalBehaviors,
                 globalModules,
                 additionInit,

--- a/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/hybridkit/lynx/HybridLynxKit.kt
+++ b/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/hybridkit/lynx/HybridLynxKit.kt
@@ -106,12 +106,15 @@ object HybridLynxKit {
         }
         applyThreadStrategy(viewBuilder, sparklingContext?.threadStrategy, lynxConfig?.defaultThreadStrategy)
         var lynxViewRef: SimpleLynxKitView? = null
-        (lynxConfig?.templateProvider ?: LynxEnv.inst().templateProvider)?.let { templateProvider ->
-            viewBuilder.setTemplateProvider(
-                SimpleLynxTemplateProvider(templateProvider, lifeCycle) {
-                    lynxViewRef
-                },
-            )
+        val resourceFetcherConfig =
+            SparklingResourceFetcherConfigurator.resolve(sparklingContext, lynxConfig)
+        SparklingResourceFetcherConfigurator.apply(
+            viewBuilder,
+            resourceFetcherConfig,
+            lynxConfig?.templateProvider ?: LynxEnv.inst().templateProvider,
+            lifeCycle,
+        ) {
+            lynxViewRef
         }
         val bridge = SparklingBridge()
         bridge.registerLynxModule(viewBuilder, hybridContext.containerId)

--- a/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/hybridkit/lynx/SparklingResourceFetcherConfigurator.kt
+++ b/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/hybridkit/lynx/SparklingResourceFetcherConfigurator.kt
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 TikTok Pte. Ltd.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+package com.tiktok.sparkling.hybridkit.lynx
+
+import com.lynx.tasm.LynxBooleanOption
+import com.lynx.tasm.LynxViewBuilder
+import com.lynx.tasm.provider.AbsTemplateProvider
+import com.tiktok.sparkling.SparklingContext
+import com.tiktok.sparkling.SparklingResourceFetcherConfig
+import com.tiktok.sparkling.hybridkit.base.IHybridKitLifeCycle
+import com.tiktok.sparkling.hybridkit.config.SparklingLynxConfig
+
+internal object SparklingResourceFetcherConfigurator {
+    fun resolve(
+        sparklingContext: SparklingContext?,
+        lynxConfig: SparklingLynxConfig?,
+    ): SparklingResourceFetcherConfig? =
+        sparklingContext?.resourceFetcherConfig
+            ?: sparklingContext?.let { lynxConfig?.resourceFetcherFactory?.create(it) }
+
+    fun apply(
+        viewBuilder: LynxViewBuilder,
+        config: SparklingResourceFetcherConfig?,
+        defaultTemplateProvider: AbsTemplateProvider?,
+        lifeCycle: IHybridKitLifeCycle?,
+        kitViewProvider: () -> SimpleLynxKitView?,
+    ) {
+        config?.genericResourceFetcher?.let {
+            viewBuilder.setGenericResourceFetcher(it)
+            viewBuilder.setEnableGenericResourceFetcher(LynxBooleanOption.TRUE)
+        }
+        config?.mediaResourceFetcher?.let {
+            viewBuilder.setMediaResourceFetcher(it)
+        }
+        val templateResourceFetcher = config?.templateResourceFetcher
+        if (templateResourceFetcher != null) {
+            viewBuilder.setTemplateResourceFetcher(
+                SparklingTemplateResourceFetcher(
+                    templateResourceFetcher,
+                    lifeCycle,
+                    kitViewProvider,
+                ),
+            )
+        } else {
+            defaultTemplateProvider?.let {
+                viewBuilder.setTemplateProvider(
+                    SimpleLynxTemplateProvider(it, lifeCycle, kitViewProvider),
+                )
+            }
+        }
+    }
+}

--- a/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/hybridkit/lynx/SparklingTemplateResourceFetcher.kt
+++ b/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/hybridkit/lynx/SparklingTemplateResourceFetcher.kt
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 TikTok Pte. Ltd.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+package com.tiktok.sparkling.hybridkit.lynx
+
+import com.lynx.tasm.resourceprovider.LynxResourceCallback
+import com.lynx.tasm.resourceprovider.LynxResourceRequest
+import com.lynx.tasm.resourceprovider.LynxResourceResponse
+import com.lynx.tasm.resourceprovider.template.LynxTemplateResourceFetcher
+import com.lynx.tasm.resourceprovider.template.TemplateProviderResult
+import com.tiktok.sparkling.hybridkit.base.HybridErrorConstantCode
+import com.tiktok.sparkling.hybridkit.base.HybridKitError
+import com.tiktok.sparkling.hybridkit.base.IHybridKitLifeCycle
+import com.tiktok.sparkling.hybridkit.base.IKitView
+import java.util.concurrent.atomic.AtomicBoolean
+
+internal class SparklingTemplateResourceFetcher(
+    private val delegate: LynxTemplateResourceFetcher,
+    private val lifeCycle: IHybridKitLifeCycle?,
+    private val kitViewProvider: () -> IKitView?,
+) : LynxTemplateResourceFetcher() {
+    override fun fetchTemplate(
+        request: LynxResourceRequest,
+        callback: LynxResourceCallback<TemplateProviderResult>,
+    ) {
+        notifyResourceLoadStart(request.url)
+        val wrappedCallback =
+            onceCallback(request.url, callback) { response ->
+                response.data?.templateBinary
+            }
+        runCatching {
+            delegate.fetchTemplate(request, wrappedCallback)
+        }.onFailure {
+            wrappedCallback.onResponse(failedResponse(it))
+        }
+    }
+
+    override fun fetchSSRData(
+        request: LynxResourceRequest,
+        callback: LynxResourceCallback<ByteArray>,
+    ) {
+        notifyResourceLoadStart(request.url)
+        val wrappedCallback =
+            onceCallback(request.url, callback) { response ->
+                response.data
+            }
+        runCatching {
+            delegate.fetchSSRData(request, wrappedCallback)
+        }.onFailure {
+            wrappedCallback.onResponse(failedResponse(it))
+        }
+    }
+
+    private fun <T> onceCallback(
+        url: String,
+        callback: LynxResourceCallback<T>,
+        templateProvider: (LynxResourceResponse<T>) -> ByteArray?,
+    ): LynxResourceCallback<T> {
+        val completed = AtomicBoolean(false)
+        return LynxResourceCallback { response ->
+            if (!completed.compareAndSet(false, true)) {
+                return@LynxResourceCallback
+            }
+            val error =
+                if (response.state == LynxResourceResponse.ResponseState.FAILED) {
+                    HybridKitError().apply {
+                        errorCode = HybridErrorConstantCode.ResourceLoadError
+                        errorReason = "ResourceLoadFailed"
+                        originReason = response.error?.message
+                    }
+                } else {
+                    null
+                }
+            notifyResourceLoadFinish(url, templateProvider(response), error)
+            callback.onResponse(response)
+        }
+    }
+
+    private fun notifyResourceLoadStart(url: String) {
+        val kitView = kitViewProvider()?.takeIf { !it.hasDestroyed() } ?: return
+        lifeCycle?.onResourceLoadStart(kitView, url)
+    }
+
+    private fun notifyResourceLoadFinish(
+        url: String,
+        template: ByteArray?,
+        error: HybridKitError?,
+    ) {
+        val kitView = kitViewProvider()?.takeIf { !it.hasDestroyed() } ?: return
+        lifeCycle?.onResourceLoadFinish(kitView, url, template, error)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> failedResponse(error: Throwable): LynxResourceResponse<T> = LynxResourceResponse.onFailed(error) as LynxResourceResponse<T>
+}

--- a/packages/sparkling-sdk/android/sparkling/src/test/java/com/tiktok/sparkling/SparklingResourceFetcherConfigTest.kt
+++ b/packages/sparkling-sdk/android/sparkling/src/test/java/com/tiktok/sparkling/SparklingResourceFetcherConfigTest.kt
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 TikTok Pte. Ltd.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+package com.tiktok.sparkling
+
+import com.lynx.tasm.resourceprovider.generic.LynxGenericResourceFetcher
+import com.lynx.tasm.resourceprovider.media.LynxMediaResourceFetcher
+import com.lynx.tasm.resourceprovider.template.LynxTemplateResourceFetcher
+import io.mockk.mockk
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class SparklingResourceFetcherConfigTest {
+    @Test
+    fun builderDefaultsToNoFetchers() {
+        val config = SparklingResourceFetcherConfig.builder().build()
+
+        assertNull(config.genericResourceFetcher)
+        assertNull(config.mediaResourceFetcher)
+        assertNull(config.templateResourceFetcher)
+    }
+
+    @Test
+    fun builderStoresTypedFetchers() {
+        val genericFetcher = mockk<LynxGenericResourceFetcher>()
+        val mediaFetcher = mockk<LynxMediaResourceFetcher>()
+        val templateFetcher = mockk<LynxTemplateResourceFetcher>()
+
+        val config =
+            SparklingResourceFetcherConfig
+                .builder()
+                .setGenericResourceFetcher(genericFetcher)
+                .setMediaResourceFetcher(mediaFetcher)
+                .setTemplateResourceFetcher(templateFetcher)
+                .build()
+
+        assertSame(genericFetcher, config.genericResourceFetcher)
+        assertSame(mediaFetcher, config.mediaResourceFetcher)
+        assertSame(templateFetcher, config.templateResourceFetcher)
+    }
+}

--- a/packages/sparkling-sdk/android/sparkling/src/test/java/com/tiktok/sparkling/SparklingResourceFetcherJavaApiTest.java
+++ b/packages/sparkling-sdk/android/sparkling/src/test/java/com/tiktok/sparkling/SparklingResourceFetcherJavaApiTest.java
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 TikTok Pte. Ltd.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+package com.tiktok.sparkling;
+
+import static org.junit.Assert.assertSame;
+
+import android.app.Application;
+import com.tiktok.sparkling.hybridkit.config.SparklingLynxConfig;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 33, packageName = "com.tiktok.sparkling")
+public class SparklingResourceFetcherJavaApiTest {
+  @Test
+  public void javaCanConfigurePageOverrideAndGlobalFactory() {
+    SparklingResourceFetcherConfig pageConfig =
+        SparklingResourceFetcherConfig.builder()
+            .setGenericResourceFetcher(null)
+            .setMediaResourceFetcher(null)
+            .setTemplateResourceFetcher(null)
+            .build();
+    SparklingContext sparklingContext = new SparklingContext();
+    sparklingContext.setResourceFetcherConfig(pageConfig);
+
+    SparklingResourceFetcherFactory factory = context -> pageConfig;
+    Application application = RuntimeEnvironment.getApplication();
+    SparklingLynxConfig.Builder builder = new SparklingLynxConfig.Builder(application);
+    builder.setResourceFetcherFactory(factory);
+    SparklingLynxConfig lynxConfig = builder.build();
+
+    assertSame(pageConfig, sparklingContext.getResourceFetcherConfig());
+    assertSame(pageConfig, lynxConfig.getResourceFetcherFactory().create(sparklingContext));
+  }
+}

--- a/packages/sparkling-sdk/android/sparkling/src/test/java/com/tiktok/sparkling/hybridkit/config/HybridConfigTest.kt
+++ b/packages/sparkling-sdk/android/sparkling/src/test/java/com/tiktok/sparkling/hybridkit/config/HybridConfigTest.kt
@@ -2,6 +2,9 @@ package com.tiktok.sparkling.hybridkit.config
 
 import android.app.Application
 import com.lynx.tasm.LynxEnv
+import com.tiktok.sparkling.SparklingContext
+import com.tiktok.sparkling.SparklingResourceFetcherConfig
+import com.tiktok.sparkling.SparklingResourceFetcherFactory
 import com.tiktok.sparkling.SparklingThreadStrategy
 import com.tiktok.sparkling.hybridkit.lynx.SparklingLynxModuleWrapper
 import io.mockk.mockk
@@ -105,6 +108,7 @@ class HybridConfigTest {
         assertTrue(empty.isCheckPropsSetter)
         assertNull(empty.libraryLoader)
         assertNull(empty.templateProvider)
+        assertNull(empty.resourceFetcherFactory)
         assertTrue(empty.globalBehaviors.isEmpty())
         assertTrue(empty.globalModules.isEmpty())
         assertNotNull(empty.additionInit)
@@ -112,18 +116,29 @@ class HybridConfigTest {
         assertNull(empty.defaultThreadStrategy)
 
         val moduleWrapper = mockk<SparklingLynxModuleWrapper>(relaxed = true)
+        val resourceFetcherConfig = SparklingResourceFetcherConfig.builder().build()
+        val resourceFetcherFactory =
+            SparklingResourceFetcherFactory {
+                resourceFetcherConfig
+            }
         var initCalled = false
         val cfg =
             SparklingLynxConfig.build(app) {
                 setCheckPropsSetter(false)
                 setLibraryLoader(null)
                 setTemplateProvider(null)
+                setResourceFetcherFactory(resourceFetcherFactory)
                 addLynxModules(mapOf("foo" to moduleWrapper))
                 setAdditionInit { initCalled = true }
                 setDefaultThreadStrategy(SparklingThreadStrategy.MULTI_THREADS)
             }
 
         assertFalse(cfg.isCheckPropsSetter)
+        assertSame(resourceFetcherFactory, cfg.resourceFetcherFactory)
+        assertSame(
+            resourceFetcherConfig,
+            cfg.resourceFetcherFactory?.create(SparklingContext()),
+        )
         assertEquals(1, cfg.globalModules.size)
         assertSame(moduleWrapper, cfg.globalModules["foo"])
         assertEquals(SparklingThreadStrategy.MULTI_THREADS, cfg.defaultThreadStrategy)

--- a/packages/sparkling-sdk/android/sparkling/src/test/java/com/tiktok/sparkling/hybridkit/lynx/SparklingResourceFetcherConfiguratorTest.kt
+++ b/packages/sparkling-sdk/android/sparkling/src/test/java/com/tiktok/sparkling/hybridkit/lynx/SparklingResourceFetcherConfiguratorTest.kt
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 TikTok Pte. Ltd.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+package com.tiktok.sparkling.hybridkit.lynx
+
+import android.app.Application
+import com.lynx.tasm.LynxBooleanOption
+import com.lynx.tasm.LynxViewBuilder
+import com.lynx.tasm.provider.AbsTemplateProvider
+import com.lynx.tasm.resourceprovider.generic.LynxGenericResourceFetcher
+import com.lynx.tasm.resourceprovider.media.LynxMediaResourceFetcher
+import com.lynx.tasm.resourceprovider.template.LynxTemplateResourceFetcher
+import com.tiktok.sparkling.SparklingContext
+import com.tiktok.sparkling.SparklingResourceFetcherConfig
+import com.tiktok.sparkling.SparklingResourceFetcherFactory
+import com.tiktok.sparkling.hybridkit.config.SparklingLynxConfig
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class SparklingResourceFetcherConfiguratorTest {
+    @Test
+    fun pageConfigTakesPrecedenceOverGlobalFactory() {
+        val pageConfig = SparklingResourceFetcherConfig.builder().build()
+        val globalConfig = SparklingResourceFetcherConfig.builder().build()
+        val sparklingContext =
+            SparklingContext().apply {
+                resourceFetcherConfig = pageConfig
+            }
+        var factoryCalls = 0
+        val lynxConfig =
+            SparklingLynxConfig.build(mockk<Application>()) {
+                setResourceFetcherFactory(
+                    SparklingResourceFetcherFactory {
+                        factoryCalls += 1
+                        globalConfig
+                    },
+                )
+            }
+
+        val resolved = SparklingResourceFetcherConfigurator.resolve(sparklingContext, lynxConfig)
+
+        assertSame(pageConfig, resolved)
+        assertEquals(0, factoryCalls)
+    }
+
+    @Test
+    fun globalFactoryCreatesPerPageConfigWhenOverrideIsAbsent() {
+        val globalConfig = SparklingResourceFetcherConfig.builder().build()
+        val sparklingContext = SparklingContext()
+        var receivedContext: SparklingContext? = null
+        val lynxConfig =
+            SparklingLynxConfig.build(mockk<Application>()) {
+                setResourceFetcherFactory(
+                    SparklingResourceFetcherFactory {
+                        receivedContext = it
+                        globalConfig
+                    },
+                )
+            }
+
+        val resolved = SparklingResourceFetcherConfigurator.resolve(sparklingContext, lynxConfig)
+
+        assertSame(globalConfig, resolved)
+        assertSame(sparklingContext, receivedContext)
+    }
+
+    @Test
+    fun resolveReturnsNullWithoutPageConfigOrFactory() {
+        assertNull(SparklingResourceFetcherConfigurator.resolve(SparklingContext(), null))
+    }
+
+    @Test
+    fun applyInstallsTypedFetchersAndEnablesGenericFetching() {
+        val viewBuilder = mockk<LynxViewBuilder>(relaxed = true)
+        val genericFetcher = mockk<LynxGenericResourceFetcher>()
+        val mediaFetcher = mockk<LynxMediaResourceFetcher>()
+        val templateFetcher = mockk<LynxTemplateResourceFetcher>()
+        val config =
+            SparklingResourceFetcherConfig
+                .builder()
+                .setGenericResourceFetcher(genericFetcher)
+                .setMediaResourceFetcher(mediaFetcher)
+                .setTemplateResourceFetcher(templateFetcher)
+                .build()
+
+        SparklingResourceFetcherConfigurator.apply(
+            viewBuilder,
+            config,
+            mockk<AbsTemplateProvider>(),
+            null,
+        ) { null }
+
+        verify(exactly = 1) { viewBuilder.setGenericResourceFetcher(genericFetcher) }
+        verify(exactly = 1) {
+            viewBuilder.setEnableGenericResourceFetcher(LynxBooleanOption.TRUE)
+        }
+        verify(exactly = 1) { viewBuilder.setMediaResourceFetcher(mediaFetcher) }
+        verify(exactly = 1) {
+            viewBuilder.setTemplateResourceFetcher(any<SparklingTemplateResourceFetcher>())
+        }
+        verify(exactly = 0) { viewBuilder.setTemplateProvider(any()) }
+    }
+
+    @Test
+    fun applyKeepsDefaultTemplateProviderPathWhenTypedTemplateIsUnset() {
+        val viewBuilder = mockk<LynxViewBuilder>(relaxed = true)
+        val defaultTemplateProvider = mockk<AbsTemplateProvider>()
+
+        SparklingResourceFetcherConfigurator.apply(
+            viewBuilder,
+            SparklingResourceFetcherConfig.builder().build(),
+            defaultTemplateProvider,
+            null,
+        ) { null }
+
+        verify(exactly = 1) {
+            viewBuilder.setTemplateProvider(any<SimpleLynxTemplateProvider>())
+        }
+        verify(exactly = 0) { viewBuilder.setTemplateResourceFetcher(any()) }
+        verify(exactly = 0) {
+            viewBuilder.setEnableGenericResourceFetcher(any())
+        }
+    }
+}

--- a/packages/sparkling-sdk/android/sparkling/src/test/java/com/tiktok/sparkling/hybridkit/lynx/SparklingTemplateResourceFetcherTest.kt
+++ b/packages/sparkling-sdk/android/sparkling/src/test/java/com/tiktok/sparkling/hybridkit/lynx/SparklingTemplateResourceFetcherTest.kt
@@ -1,0 +1,205 @@
+// Copyright (c) 2026 TikTok Pte. Ltd.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+package com.tiktok.sparkling.hybridkit.lynx
+
+import com.lynx.tasm.resourceprovider.LynxResourceCallback
+import com.lynx.tasm.resourceprovider.LynxResourceRequest
+import com.lynx.tasm.resourceprovider.LynxResourceResponse
+import com.lynx.tasm.resourceprovider.template.LynxTemplateResourceFetcher
+import com.lynx.tasm.resourceprovider.template.TemplateProviderResult
+import com.tiktok.sparkling.hybridkit.base.HybridKitError
+import com.tiktok.sparkling.hybridkit.base.IHybridKitLifeCycle
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(
+    sdk = [33],
+    packageName = "com.tiktok.sparkling",
+)
+class SparklingTemplateResourceFetcherTest {
+    private lateinit var delegate: RecordingTemplateResourceFetcher
+    private lateinit var kitView: SimpleLynxKitView
+    private lateinit var lifeCycle: IHybridKitLifeCycle
+    private lateinit var fetcher: SparklingTemplateResourceFetcher
+
+    @Before
+    fun setUp() {
+        clearAllMocks()
+        delegate = RecordingTemplateResourceFetcher()
+        kitView = mockk(relaxed = true)
+        lifeCycle = mockk(relaxed = true)
+        every { kitView.hasDestroyed() } returns false
+        fetcher = SparklingTemplateResourceFetcher(delegate, lifeCycle) { kitView }
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun templateSuccessForwardsExactlyOnce() {
+        val request = templateRequest()
+        val callback = RecordingCallback<TemplateProviderResult>()
+        val binary = byteArrayOf(1, 2, 3)
+        val response = LynxResourceResponse.onSuccess(TemplateProviderResult.fromBinary(binary))
+
+        fetcher.fetchTemplate(request, callback)
+        delegate.templateCallback?.onResponse(response)
+        delegate.templateCallback?.onResponse(response)
+
+        verify(exactly = 1) { lifeCycle.onResourceLoadStart(kitView, request.url) }
+        verify(exactly = 1) {
+            lifeCycle.onResourceLoadFinish(kitView, request.url, binary, null)
+        }
+        assertEquals(1, callback.responses.size)
+        assertArrayEquals(
+            binary,
+            callback.responses
+                .single()
+                .data.templateBinary,
+        )
+    }
+
+    @Test
+    fun templateFailureForwardsExactlyOnce() {
+        val request = templateRequest()
+        val callback = RecordingCallback<TemplateProviderResult>()
+        val errorSlot = slot<HybridKitError>()
+        val response =
+            failedResponse<TemplateProviderResult>(IllegalStateException("template failed"))
+
+        fetcher.fetchTemplate(request, callback)
+        delegate.templateCallback?.onResponse(response)
+        delegate.templateCallback?.onResponse(response)
+
+        verify(exactly = 1) {
+            lifeCycle.onResourceLoadFinish(
+                kitView,
+                request.url,
+                null,
+                capture(errorSlot),
+            )
+        }
+        assertEquals("ResourceLoadFailed", errorSlot.captured.errorReason)
+        assertEquals("template failed", errorSlot.captured.originReason)
+        assertEquals(1, callback.responses.size)
+    }
+
+    @Test
+    fun ssrSuccessAndFailureEachCompleteExactlyOnce() {
+        val successRequest = templateRequest("https://example.com/page.ssr")
+        val successCallback = RecordingCallback<ByteArray>()
+        val successData = byteArrayOf(4, 5, 6)
+
+        fetcher.fetchSSRData(successRequest, successCallback)
+        delegate.ssrCallback?.onResponse(LynxResourceResponse.onSuccess(successData))
+        delegate.ssrCallback?.onResponse(LynxResourceResponse.onSuccess(successData))
+
+        verify(exactly = 1) {
+            lifeCycle.onResourceLoadFinish(kitView, successRequest.url, successData, null)
+        }
+        assertEquals(1, successCallback.responses.size)
+
+        val failureRequest = templateRequest("https://example.com/failure.ssr")
+        val failureCallback = RecordingCallback<ByteArray>()
+        val failureResponse = failedResponse<ByteArray>(IllegalStateException("ssr failed"))
+
+        fetcher.fetchSSRData(failureRequest, failureCallback)
+        delegate.ssrCallback?.onResponse(failureResponse)
+        delegate.ssrCallback?.onResponse(failureResponse)
+
+        verify(exactly = 1) {
+            lifeCycle.onResourceLoadFinish(
+                kitView,
+                failureRequest.url,
+                null,
+                any<HybridKitError>(),
+            )
+        }
+        assertEquals(1, failureCallback.responses.size)
+    }
+
+    @Test
+    fun synchronousDelegateExceptionBecomesOneFailure() {
+        val request = templateRequest()
+        val callback = RecordingCallback<TemplateProviderResult>()
+        delegate.templateFailure = IllegalStateException("thrown")
+
+        fetcher.fetchTemplate(request, callback)
+
+        verify(exactly = 1) {
+            lifeCycle.onResourceLoadFinish(
+                kitView,
+                request.url,
+                null,
+                any<HybridKitError>(),
+            )
+        }
+        assertEquals(1, callback.responses.size)
+        assertEquals(
+            LynxResourceResponse.ResponseState.FAILED,
+            callback.responses.single().state,
+        )
+        assertEquals(
+            "thrown",
+            callback.responses
+                .single()
+                .error.message,
+        )
+    }
+
+    private fun templateRequest(
+        url: String = "https://example.com/main.lynx.bundle",
+    ): LynxResourceRequest =
+        LynxResourceRequest(
+            url,
+            LynxResourceRequest.LynxResourceType.LynxResourceTypeTemplate,
+        )
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> failedResponse(error: Throwable): LynxResourceResponse<T> = LynxResourceResponse.onFailed(error) as LynxResourceResponse<T>
+
+    private class RecordingTemplateResourceFetcher : LynxTemplateResourceFetcher() {
+        var templateCallback: LynxResourceCallback<TemplateProviderResult>? = null
+        var ssrCallback: LynxResourceCallback<ByteArray>? = null
+        var templateFailure: Throwable? = null
+
+        override fun fetchTemplate(
+            request: LynxResourceRequest,
+            callback: LynxResourceCallback<TemplateProviderResult>,
+        ) {
+            templateFailure?.let { throw it }
+            templateCallback = callback
+        }
+
+        override fun fetchSSRData(
+            request: LynxResourceRequest,
+            callback: LynxResourceCallback<ByteArray>,
+        ) {
+            ssrCallback = callback
+        }
+    }
+
+    private class RecordingCallback<T> : LynxResourceCallback<T> {
+        val responses = mutableListOf<LynxResourceResponse<T>>()
+
+        override fun onResponse(response: LynxResourceResponse<T>) {
+            responses += response
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Add typed page-level Android Lynx resource fetchers while preserving Sparkling template and SSR lifecycle reporting.

This is the fifth layer of the Android compatibility stack and depends on the typed thread-strategy layer.

## Changes
- Add Java-friendly generic, media, and template fetcher configuration.
- Support per-page override and optional global per-page factory.
- Automatically enable generic fetching when configured.
- Wrap typed template/SSR fetchers so start/finish/error forwarding remains exactly once.
- Preserve the existing template-provider path when unset.
- Add Kotlin and Java API tests plus lifecycle success/failure/duplicate-callback coverage.

## How to test
- Focused SDK tests passed on SG1/JDK 11.
- Kotlin lint passed.
- Cloud-device fetch invocation and first-screen verification will be attached before completion.

## Stack
#119 -> #120 -> #121 -> typed thread strategy -> **this PR**

## Checklist
- [x] I read `CONTRIBUTING.md`.
- [x] I ran relevant checks.
- [x] I updated docs and tests.


## Device validation complete

The durable SG1 + Lynx Sandbox acceptance matrix is now available in #131. Exact validated commit: `8a2b3ea99eaa342e2f1ebfe716aefbb44f411fbb`. On a fresh `aries_10` device (Android 10 / API 29), all 9 tests passed, including real first-screen rendering, fixed `320x480`, shared density `3.25` across two independent Lynx views, `PART_ON_LAYOUT`, typed template fetch invocation, orientation, retry recovery, and unsafe configuration rejection. The runner dynamically leases/releases the device and archives logs/screenshots/hashes. Evidence archive on SG1: `/tmp/sparkling-android-device-acceptance-8a2b3ea.tar.gz` (SHA-256 `09acd64b4b63988b61e7f4f2ff11f3f7b4b4770bd3ef74a973db6dda0c9e242c`).


## Expanded durable device validation

The checked-in SG1 + Lynx Sandbox matrix in #131 now validates exact commit `df875a87541d587ab8aa84a86600c0610f9e44c7` with **10/10 PASS** on `aries_10` (Android 10 / API 29). Added runtime coverage includes: the pre-load listener observing a ready bridge before template fetch; the global per-page fetcher factory; real first-screen rendering for `ALL_ON_UI`, `MOST_ON_TASM`, `PART_ON_LAYOUT`, and safe `MULTI_THREADS`; and full-page fixed-viewport + `MULTI_THREADS` rejection before Activity launch or transfer-station save. The runner requires a clean exact HEAD and fails closed unless Sandbox release confirms the leased serial. Evidence: `/tmp/sparkling-android-device-acceptance-df875a8`; archive SHA-256 `712a3b83dbd78eabeae9afc0766b5b191cee0bff10e515967b3ae9f46c4feb98`.
