### PR TITLE
[BugFix][iOS] Avoid host orientation recursion

### DIFF
--- a/packages/playground/ios/SparklingGoTests/Application/SPKRouterTests.swift
+++ b/packages/playground/ios/SparklingGoTests/Application/SPKRouterTests.swift
@@ -115,6 +115,33 @@ struct SPKRouterTests {
         }
     }
 
+    @Test func navigationControllerUsesNonSparklingTopControllerPolicy() {
+        final class HostViewController: UIViewController {
+            override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+                .portraitUpsideDown
+            }
+
+            override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
+                .portraitUpsideDown
+            }
+        }
+
+        let delegate = SPKViewController(
+            withURL: nil,
+            config: SPKSchemeParam(),
+            context: SPKContext(),
+            frame: .zero)
+        let host = HostViewController()
+        let navigationController = UINavigationController(rootViewController: host)
+
+        #expect(
+            delegate.navigationControllerSupportedInterfaceOrientations(
+                navigationController) == .portraitUpsideDown)
+        #expect(
+            delegate.navigationControllerPreferredInterfaceOrientationForPresentation(
+                navigationController) == .portraitUpsideDown)
+    }
+
     @Test func viewAppearanceSchedulesPortraitGeometryUpdate() {
         let context = SPKContext()
         context.interfaceOrientationPolicy = .portrait

--- a/packages/sparkling-sdk/ios/Sparkling/Sources/Application/Container/SPKViewController.swift
+++ b/packages/sparkling-sdk/ios/Sparkling/Sources/Application/Container/SPKViewController.swift
@@ -1121,16 +1121,16 @@ extension SPKViewController: UINavigationControllerDelegate {
     public func navigationControllerSupportedInterfaceOrientations(
         _ navigationController: UINavigationController
     ) -> UIInterfaceOrientationMask {
-        return (navigationController.topViewController as? SPKViewController)?
-            .supportedInterfaceOrientations ?? navigationController.supportedInterfaceOrientations
+        return navigationController.topViewController?.supportedInterfaceOrientations
+            ?? super.supportedInterfaceOrientations
     }
 
     public func navigationControllerPreferredInterfaceOrientationForPresentation(
         _ navigationController: UINavigationController
     ) -> UIInterfaceOrientation {
-        return (navigationController.topViewController as? SPKViewController)?
+        return navigationController.topViewController?
             .preferredInterfaceOrientationForPresentation
-            ?? navigationController.preferredInterfaceOrientationForPresentation
+            ?? super.preferredInterfaceOrientationForPresentation
     }
 }
 


### PR DESCRIPTION
## Summary
- use the navigation stack's actual top controller as the orientation source
- avoid recursively asking `UINavigationController` for the same delegate-owned policy
- preserve typed Sparkling orientation when the top controller is an `SPKViewController`

## Regression
A Sparkling-owned navigation stack can later present a non-Sparkling tooling controller. The previous fallback called `navigationController.supportedInterfaceOrientations` from the navigation delegate itself, recursively re-entering the same callback until the main-thread stack overflowed.

## Validation
- `SparklingGoTests`: 337 tests in 20 suites passed on iOS Simulator
- new coverage uses a non-Sparkling top controller with an explicit orientation policy

## Stack
- base: #128