### PR TITLE
[BugFix][Android] Enable typed resource fetcher pipeline

### DIFF
--- a/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/hybridkit/lynx/SparklingResourceFetcherConfigurator.kt
+++ b/packages/sparkling-sdk/android/sparkling/src/main/java/com/tiktok/sparkling/hybridkit/lynx/SparklingResourceFetcherConfigurator.kt
@@ -26,9 +26,15 @@ internal object SparklingResourceFetcherConfigurator {
         lifeCycle: IHybridKitLifeCycle?,
         kitViewProvider: () -> SimpleLynxKitView?,
     ) {
+        val hasTypedFetcher =
+            config?.genericResourceFetcher != null ||
+                config?.mediaResourceFetcher != null ||
+                config?.templateResourceFetcher != null
+        if (hasTypedFetcher) {
+            viewBuilder.setEnableGenericResourceFetcher(LynxBooleanOption.TRUE)
+        }
         config?.genericResourceFetcher?.let {
             viewBuilder.setGenericResourceFetcher(it)
-            viewBuilder.setEnableGenericResourceFetcher(LynxBooleanOption.TRUE)
         }
         config?.mediaResourceFetcher?.let {
             viewBuilder.setMediaResourceFetcher(it)

--- a/packages/sparkling-sdk/android/sparkling/src/test/java/com/tiktok/sparkling/hybridkit/lynx/SparklingResourceFetcherConfiguratorTest.kt
+++ b/packages/sparkling-sdk/android/sparkling/src/test/java/com/tiktok/sparkling/hybridkit/lynx/SparklingResourceFetcherConfiguratorTest.kt
@@ -106,6 +106,60 @@ class SparklingResourceFetcherConfiguratorTest {
     }
 
     @Test
+    fun applyEnablesResourcePipelineForTemplateOnlyFetcher() {
+        val viewBuilder = mockk<LynxViewBuilder>(relaxed = true)
+        val templateFetcher = mockk<LynxTemplateResourceFetcher>()
+        val config =
+            SparklingResourceFetcherConfig
+                .builder()
+                .setTemplateResourceFetcher(templateFetcher)
+                .build()
+
+        SparklingResourceFetcherConfigurator.apply(
+            viewBuilder,
+            config,
+            mockk<AbsTemplateProvider>(),
+            null,
+        ) { null }
+
+        verify(exactly = 1) {
+            viewBuilder.setEnableGenericResourceFetcher(LynxBooleanOption.TRUE)
+        }
+        verify(exactly = 1) {
+            viewBuilder.setTemplateResourceFetcher(any<SparklingTemplateResourceFetcher>())
+        }
+        verify(exactly = 0) { viewBuilder.setGenericResourceFetcher(any()) }
+        verify(exactly = 0) { viewBuilder.setMediaResourceFetcher(any()) }
+    }
+
+    @Test
+    fun applyEnablesResourcePipelineForMediaOnlyFetcher() {
+        val viewBuilder = mockk<LynxViewBuilder>(relaxed = true)
+        val mediaFetcher = mockk<LynxMediaResourceFetcher>()
+        val config =
+            SparklingResourceFetcherConfig
+                .builder()
+                .setMediaResourceFetcher(mediaFetcher)
+                .build()
+
+        SparklingResourceFetcherConfigurator.apply(
+            viewBuilder,
+            config,
+            mockk<AbsTemplateProvider>(),
+            null,
+        ) { null }
+
+        verify(exactly = 1) {
+            viewBuilder.setEnableGenericResourceFetcher(LynxBooleanOption.TRUE)
+        }
+        verify(exactly = 1) { viewBuilder.setMediaResourceFetcher(mediaFetcher) }
+        verify(exactly = 0) { viewBuilder.setGenericResourceFetcher(any()) }
+        verify(exactly = 1) {
+            viewBuilder.setTemplateProvider(any<SimpleLynxTemplateProvider>())
+        }
+    }
+
+    @Test
     fun applyKeepsDefaultTemplateProviderPathWhenTypedTemplateIsUnset() {
         val viewBuilder = mockk<LynxViewBuilder>(relaxed = true)
         val defaultTemplateProvider = mockk<AbsTemplateProvider>()


### PR DESCRIPTION
## Summary

- enable the Lynx resource pipeline when any typed generic, media, or template fetcher is configured
- fix template-only and media-only configurations being silently ignored at runtime
- add focused regression coverage for template-only and media-only configurations

## Root cause

Lynx 3.9 only installs typed template/media fetchers when `setEnableGenericResourceFetcher(TRUE)` is set. Sparkling previously enabled that switch only when a generic fetcher existed, so template-only and media-only configurations fell back to the legacy template provider.

## Validation

- `:sparkling:testDebugUnitTest --tests com.tiktok.sparkling.hybridkit.lynx.SparklingResourceFetcherConfiguratorTest`
- `:app:assembleDebug :app:assembleDebugAndroidTest` on SG1
- Lynx Sandbox `aries_10`, Android 10/API 29: template-only page fetcher loaded a real bundle, emitted first-screen/load-finish, and passed fixed viewport `320x480`, density `3.25`, and `PART_ON_LAYOUT` assertions

## Stack

- base: #127
- acceptance fixtures will follow in a separate stacked PR

## Expanded durable device validation

The checked-in SG1 + Lynx Sandbox matrix in #131 now validates exact commit `df875a87541d587ab8aa84a86600c0610f9e44c7` with **10/10 PASS** on `aries_10` (Android 10 / API 29). Added runtime coverage includes: the pre-load listener observing a ready bridge before template fetch; the global per-page fetcher factory; real first-screen rendering for `ALL_ON_UI`, `MOST_ON_TASM`, `PART_ON_LAYOUT`, and safe `MULTI_THREADS`; and full-page fixed-viewport + `MULTI_THREADS` rejection before Activity launch or transfer-station save. The runner requires a clean exact HEAD and fails closed unless Sandbox release confirms the leased serial. Evidence: `/tmp/sparkling-android-device-acceptance-df875a8`; archive SHA-256 `712a3b83dbd78eabeae9afc0766b5b191cee0bff10e515967b3ae9f46c4feb98`.
