### PR TITLE
fix(cli): handle Java doctor process output

### DIFF
--- a/packages/sparkling-app-cli/src/__tests__/doctor-checks.test.ts
+++ b/packages/sparkling-app-cli/src/__tests__/doctor-checks.test.ts
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 TikTok Pte. Ltd.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { execFileSync, spawnSync } from 'node:child_process';
+
+import { checkJdk } from '../commands/doctor/checks';
+
+jest.mock('node:child_process', () => ({
+  execFileSync: jest.fn(),
+  spawnSync: jest.fn(),
+}));
+
+const execFileSyncMock = jest.mocked(execFileSync);
+const spawnSyncMock = jest.mocked(spawnSync);
+
+const JAVA_NOT_INSTALLED_RESULT = {
+  name: 'JDK',
+  category: 'android',
+  expected: '>= 11',
+  status: 'fail',
+  message: 'Java is not installed or not found in PATH',
+  fixHint: 'Java (JDK) is not installed. I need JDK 11 or higher.',
+} as const;
+
+function createWindowsJavaNotFoundResult(streams: Record<string, unknown>): ReturnType<typeof spawnSync> {
+  const error = Object.assign(new Error('spawnSync java ENOENT'), {
+    errno: -4058,
+    code: 'ENOENT',
+    syscall: 'spawnSync java',
+    path: 'java',
+    spawnargs: ['-version'],
+  });
+
+  return {
+    pid: 0,
+    output: null,
+    status: null,
+    signal: null,
+    error,
+    ...streams,
+  } as unknown as ReturnType<typeof spawnSync>;
+}
+
+function createJavaVersionResult(
+  stdout: string | Buffer | null | undefined,
+  stderr: string | Buffer | null | undefined,
+): ReturnType<typeof spawnSync> {
+  return {
+    pid: 123,
+    output: [null, stdout, stderr],
+    stdout,
+    stderr,
+    status: 0,
+    signal: null,
+  } as unknown as ReturnType<typeof spawnSync>;
+}
+
+describe('checkJdk', () => {
+  beforeEach(() => {
+    execFileSyncMock.mockReset();
+    execFileSyncMock.mockReturnValue('');
+    spawnSyncMock.mockReset();
+  });
+
+  it.each([
+    ['missing streams', {}],
+    ['undefined streams', { stdout: undefined, stderr: undefined }],
+    ['null streams', { stdout: null, stderr: null }],
+  ])('reports Java as not installed for a Windows ENOENT error with %s', (_description, streams) => {
+    spawnSyncMock.mockReturnValue(createWindowsJavaNotFoundResult(streams));
+
+    expect(checkJdk()).toEqual(JAVA_NOT_INSTALLED_RESULT);
+  });
+
+  it('reads an installed Java version from stderr when the process exits successfully', () => {
+    spawnSyncMock.mockReturnValue(createJavaVersionResult('', 'openjdk version "11.0.18" 2023-01-17'));
+
+    expect(checkJdk()).toEqual({
+      name: 'JDK',
+      category: 'android',
+      expected: '>= 11',
+      status: 'pass',
+      version: '11.0.18',
+    });
+    expect(spawnSyncMock).toHaveBeenCalledWith('java', ['-version'], {
+      encoding: 'utf8',
+      shell: false,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 15_000,
+    });
+  });
+
+  it.each([
+    ['string', 'openjdk version "17.0.9" 2023-10-17'],
+    ['Buffer', Buffer.from('openjdk version "21.0.2" 2024-01-16')],
+  ])('falls back to a %s Java version on stdout', (_description, stdout) => {
+    spawnSyncMock.mockReturnValue(createJavaVersionResult(stdout, undefined));
+
+    expect(checkJdk()).toEqual(expect.objectContaining({
+      status: 'pass',
+      version: stdout instanceof Buffer ? '21.0.2' : '17.0.9',
+    }));
+  });
+
+  it('falls back to stdout when stderr is empty', () => {
+    spawnSyncMock.mockReturnValue(
+      createJavaVersionResult('openjdk version "11.0.18" 2023-01-17', Buffer.from('  \n')),
+    );
+
+    expect(checkJdk()).toEqual(expect.objectContaining({
+      status: 'pass',
+      version: '11.0.18',
+    }));
+  });
+
+  it('prefers a non-empty stderr version over stdout', () => {
+    spawnSyncMock.mockReturnValue(
+      createJavaVersionResult('java version "1.8.0_392"', 'openjdk version "17.0.9" 2023-10-17'),
+    );
+
+    expect(checkJdk()).toEqual(expect.objectContaining({
+      status: 'pass',
+      version: '17.0.9',
+    }));
+  });
+});

--- a/packages/sparkling-app-cli/src/commands/doctor/checks.ts
+++ b/packages/sparkling-app-cli/src/commands/doctor/checks.ts
@@ -2,12 +2,22 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import semver from 'semver';
 import { verboseLog } from '../../utils/verbose';
 import type { CheckResult } from './types';
+
+function normalizeProcessOutput(output: unknown): string | null {
+  if (typeof output === 'string') {
+    return output.trim() || null;
+  }
+  if (Buffer.isBuffer(output)) {
+    return output.toString('utf8').trim() || null;
+  }
+  return null;
+}
 
 /**
  * Run a command and return its stdout (trimmed).
@@ -27,54 +37,23 @@ function exec(cmd: string, args: string[]): string | null {
 }
 
 /**
- * Some tools (e.g. `java -version`) print to stderr instead of stdout.
- * This helper captures stderr.
- */
-function execStderr(cmd: string, args: string[]): string | null {
-  try {
-    execFileSync(cmd, args, {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-      timeout: 15_000,
-    });
-    return null; // if it wrote to stdout we won't get stderr this way
-  } catch (err: unknown) {
-    // execFileSync throws when the process writes to stderr even with exit 0
-    // on some Node versions, or when exit code != 0. The stderr is on the error.
-    if (err && typeof err === 'object' && 'stderr' in err) {
-      const stderr = (err as { stderr: Buffer | string }).stderr;
-      return typeof stderr === 'string' ? stderr.trim() : stderr.toString('utf8').trim();
-    }
-    return null;
-  }
-}
-
-/**
- * A more robust way to get java -version output.
- * `java -version` prints to stderr; we try to capture it both ways.
+ * Get `java -version` output, which normally prints to stderr.
  */
 function getJavaVersionOutput(): string | null {
   try {
-    const child = execFileSync('java', ['-version'], {
+    const child = spawnSync('java', ['-version'], {
       encoding: 'utf8',
+      shell: false,
       stdio: ['ignore', 'pipe', 'pipe'],
       timeout: 15_000,
     });
-    // Some environments return the output on stdout
-    if (child && child.trim()) return child.trim();
-  } catch (err: unknown) {
-    if (err && typeof err === 'object' && 'stderr' in err) {
-      const stderr = (err as { stderr: Buffer | string }).stderr;
-      const text = typeof stderr === 'string' ? stderr.trim() : stderr.toString('utf8').trim();
-      if (text) return text;
+    if (child.error) {
+      return null;
     }
-    if (err && typeof err === 'object' && 'stdout' in err) {
-      const stdout = (err as { stdout: Buffer | string }).stdout;
-      const text = typeof stdout === 'string' ? stdout.trim() : stdout.toString('utf8').trim();
-      if (text) return text;
-    }
+    return normalizeProcessOutput(child.stderr) ?? normalizeProcessOutput(child.stdout);
+  } catch {
+    return null;
   }
-  return null;
 }
 
 const NODE_REQUIRED = '^22 || ^24';


### PR DESCRIPTION
## Summary

Fix the doctor JDK probe so it handles both the normal installed-Java path and missing Java without throwing.

The root cause was that `execFileSync` only returns stdout for a successful process, while `java -version` normally exits successfully and writes its version to stderr. On Windows, a missing executable can also produce nullish or absent stdout/stderr fields, which the previous Buffer/string assumption dereferenced with `toString()`.

## Related issues

Fixes #117

## Changes

- Probe `java -version` with shell-free `spawnSync` so stdout, stderr, and spawn errors are available together.
- Prefer non-empty stderr, fall back to stdout, and safely normalize string, Buffer, missing, undefined, and null streams.
- Remove the redundant unused `execStderr` helper.
- Add deterministic child-process mocks for Windows-shaped ENOENT and installed-JDK output paths.

## How to test

Verified locally:

- `pnpm --filter sparkling-app-cli exec jest --runInBand --runTestsByPath src/__tests__/doctor-checks.test.ts` — 8 tests passed.
- `pnpm --filter sparkling-app-cli test` — 10 suites and 73 tests passed.
- `pnpm --filter sparkling-app-cli build` — passed.
- `pnpm --filter sparkling-app-cli exec tsc --noEmit --project tsconfig.jest.json` — passed.
- `git diff --check` — passed.
- Real SG1 smoke test: `java -version` reported OpenJDK 11.0.18 on stderr, then the built `checkJdk()` returned `{ status: 'pass', version: '11.0.18' }`.

Repository lint/format commands remain blocked by pre-existing tooling gaps: ESLint is not declared/installed, and the root `.prettierrc` is invalid YAML. Neither tooling file is changed here.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I linked a related issue.
- [x] I ran relevant checks.
- [x] Docs/examples are not needed for this focused bug fix.
- [x] I added regression tests.