### PR TITLE
fix(cli): invoke Rspeedy without Windows shims

### DIFF
--- a/packages/sparkling-app-cli/src/__tests__/exec.test.ts
+++ b/packages/sparkling-app-cli/src/__tests__/exec.test.ts
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 TikTok Pte. Ltd.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+// @ts-nocheck
+/// <reference types="jest" />
+import { EventEmitter } from 'node:events';
+import { runCommand } from '../utils/exec';
+
+const mockSpawn = jest.fn();
+
+jest.mock('node:child_process', () => ({
+  spawn: (...args: unknown[]) => mockSpawn(...args),
+}));
+
+describe('runCommand', () => {
+  it('keeps generic commands shell-free', async () => {
+    const child = new EventEmitter();
+    mockSpawn.mockReturnValue(child);
+    process.nextTick(() => child.emit('close', 0));
+
+    await runCommand('adb', ['devices']);
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'adb',
+      ['devices'],
+      expect.objectContaining({ shell: false }),
+    );
+  });
+});

--- a/packages/sparkling-app-cli/src/__tests__/rspeedy-invocation.test.ts
+++ b/packages/sparkling-app-cli/src/__tests__/rspeedy-invocation.test.ts
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 TikTok Pte. Ltd.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+// @ts-nocheck
+/// <reference types="jest" />
+import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { buildProject } from '../commands/build';
+import { devProject } from '../commands/dev';
+
+const fakeRspeedyBin = path.join(os.tmpdir(), 'fake rspeedy package', 'bin', 'rspeedy.js');
+const mockRunCommand = jest.fn().mockResolvedValue(undefined);
+const mockResolveRspeedyCommand = jest.fn();
+const mockSpawn = jest.fn();
+
+jest.mock('../utils/exec', () => ({
+  runCommand: (...args: unknown[]) => mockRunCommand(...args),
+}));
+
+jest.mock('../utils/rspeedy', () => ({
+  resolveRspeedyCommand: () => mockResolveRspeedyCommand(),
+}));
+
+jest.mock('node:child_process', () => {
+  const actual = jest.requireActual('node:child_process');
+  return {
+    ...actual,
+    spawn: (...args: unknown[]) => mockSpawn(...args),
+  };
+});
+
+function createClosingChild(): EventEmitter & { kill: jest.Mock } {
+  const child = new EventEmitter() as EventEmitter & { kill: jest.Mock };
+  child.kill = jest.fn();
+  process.nextTick(() => child.emit('close', 0));
+  return child;
+}
+
+function createApp(): { cwd: string } {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'sparkling app '));
+  const configPath = path.join(cwd, 'app.config.js');
+  fs.writeFileSync(configPath, 'module.exports = { lynxConfig: {} };\n');
+  return { cwd };
+}
+
+describe('Rspeedy command invocation', () => {
+  beforeEach(() => {
+    mockRunCommand.mockClear();
+    mockResolveRspeedyCommand.mockReset().mockReturnValue({
+      command: process.execPath,
+      args: [fakeRspeedyBin],
+    });
+    mockSpawn.mockReset();
+    mockSpawn.mockReturnValue(createClosingChild());
+  });
+
+  it('build invokes the resolved JavaScript bin with Node and separate arguments', async () => {
+    const { cwd } = createApp();
+
+    await buildProject({ cwd, configFile: 'app.config.js', skipCopy: true });
+
+    expect(mockRunCommand).toHaveBeenCalledWith(
+      process.execPath,
+      [
+        fakeRspeedyBin,
+        'build',
+        '--config',
+        path.join(cwd, '.sparkling', 'lynx.build.config.ts'),
+      ],
+      { cwd },
+    );
+  });
+
+  it('dev invokes the resolved JavaScript bin with Node and shell disabled', async () => {
+    const { cwd } = createApp();
+
+    await devProject({ cwd, configFile: 'app.config.js' });
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      process.execPath,
+      [
+        fakeRspeedyBin,
+        'dev',
+        '--config',
+        path.join(cwd, '.sparkling', 'lynx.dev.config.ts'),
+      ],
+      {
+        cwd,
+        env: process.env,
+        stdio: 'inherit',
+        shell: false,
+      },
+    );
+  });
+
+  it('dev loads the app config before resolving Rspeedy', async () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'sparkling missing config '));
+    mockResolveRspeedyCommand.mockImplementation(() => {
+      throw new Error('Rspeedy resolution failed');
+    });
+
+    await expect(devProject({ cwd, configFile: 'missing.config.js' }))
+      .rejects.toThrow(`App config not found at ${path.join(cwd, 'missing.config.js')}`);
+    expect(mockResolveRspeedyCommand).not.toHaveBeenCalled();
+  });
+});

--- a/packages/sparkling-app-cli/src/__tests__/rspeedy.test.ts
+++ b/packages/sparkling-app-cli/src/__tests__/rspeedy.test.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 TikTok Pte. Ltd.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { resolveRspeedyCommand } from '../utils/rspeedy';
+
+describe('resolveRspeedyCommand', () => {
+  it('resolves the JavaScript bin from package metadata without losing spaces', () => {
+    const packageDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fake rspeedy package '));
+    const manifestPath = path.join(packageDir, 'package.json');
+    const binPath = path.join(packageDir, 'bin', 'custom-rspeedy.js');
+    fs.mkdirSync(path.dirname(binPath));
+    fs.writeFileSync(binPath, '');
+    fs.writeFileSync(manifestPath, JSON.stringify({
+      bin: {
+        rspeedy: './bin/custom-rspeedy.js',
+      },
+    }));
+
+    expect(resolveRspeedyCommand(manifestPath)).toEqual({
+      command: process.execPath,
+      args: [binPath],
+    });
+  });
+
+  it('rejects package metadata without a valid rspeedy bin', () => {
+    const packageDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fake-rspeedy-'));
+    const manifestPath = path.join(packageDir, 'package.json');
+    fs.writeFileSync(manifestPath, JSON.stringify({ bin: { rspeedy: '' } }));
+
+    expect(() => resolveRspeedyCommand(manifestPath)).toThrow('bin.rspeedy');
+  });
+});

--- a/packages/sparkling-app-cli/src/commands/build.ts
+++ b/packages/sparkling-app-cli/src/commands/build.ts
@@ -4,6 +4,7 @@
 import path from 'node:path';
 import { createTempLynxConfig, loadAppConfig } from '../config';
 import { runCommand } from '../utils/exec';
+import { resolveRspeedyCommand } from '../utils/rspeedy';
 import { ui } from '../utils/ui';
 import { isVerboseEnabled, verboseLog } from '../utils/verbose';
 import { copyAssets } from './copy-assets';
@@ -17,16 +18,20 @@ export interface BuildOptions {
 export async function buildProject(options: BuildOptions): Promise<void> {
   const configPath = path.resolve(options.cwd, options.configFile ?? 'app.config.ts');
   const tempConfigPath = createTempLynxConfig(options.cwd, configPath);
-  const rspeedyBin = 'rspeedy';
+  const rspeedy = resolveRspeedyCommand();
 
   if (isVerboseEnabled()) {
     verboseLog(`App config path: ${configPath}`);
     verboseLog(`Temp Lynx config: ${tempConfigPath}`);
-    verboseLog(`rspeedy binary: ${rspeedyBin}`);
+    verboseLog(`Rspeedy binary: ${rspeedy.args[0]}`);
   }
 
   console.log(ui.headline(`Building Lynx bundle with config from ${path.relative(options.cwd, configPath)}`));
-  await runCommand(rspeedyBin, ['build', '--config', tempConfigPath], { cwd: options.cwd });
+  await runCommand(
+    rspeedy.command,
+    [...rspeedy.args, 'build', '--config', tempConfigPath],
+    { cwd: options.cwd },
+  );
 
   const shouldCopy = options.skipCopy !== true; // default to no copy
   if (shouldCopy) {

--- a/packages/sparkling-app-cli/src/commands/dev.ts
+++ b/packages/sparkling-app-cli/src/commands/dev.ts
@@ -12,6 +12,7 @@ import {
   resolveDevServerPort,
   updateDevServerPortInAppConfig,
 } from '../config';
+import { resolveRspeedyCommand } from '../utils/rspeedy';
 import { ui } from '../utils/ui';
 import { isVerboseEnabled, verboseLog } from '../utils/verbose';
 import { warnIfWildcardDevServerHost } from '../utils/dev-server-host';
@@ -64,9 +65,12 @@ export async function devProject(options: DevOptions): Promise<void> {
     }
   }
 
+  const rspeedy = resolveRspeedyCommand();
+
   if (isVerboseEnabled()) {
     verboseLog(`App config path: ${configPath}`);
     verboseLog(`Dev server port: ${port}`);
+    verboseLog(`Rspeedy binary: ${rspeedy.args[0]}`);
     if (host) {
       verboseLog(`Dev server host: ${host}`);
     }
@@ -124,7 +128,7 @@ export async function devProject(options: DevOptions): Promise<void> {
       if (isVerboseEnabled()) {
         verboseLog(`Temp Lynx config: ${tempConfigPath}`);
       }
-      child = spawn('rspeedy', ['dev', '--config', tempConfigPath], {
+      child = spawn(rspeedy.command, [...rspeedy.args, 'dev', '--config', tempConfigPath], {
         cwd: options.cwd,
         env: process.env,
         stdio: 'inherit',

--- a/packages/sparkling-app-cli/src/utils/rspeedy.ts
+++ b/packages/sparkling-app-cli/src/utils/rspeedy.ts
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 TikTok Pte. Ltd.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+const packageRequire = createRequire(__filename);
+
+export interface RspeedyCommand {
+  command: string;
+  args: string[];
+}
+
+export function resolveRspeedyCommand(
+  manifestPath = packageRequire.resolve('@lynx-js/rspeedy/package.json'),
+): RspeedyCommand {
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as {
+    bin?: Record<string, unknown>;
+  };
+  const binPath = manifest.bin?.rspeedy;
+
+  if (typeof binPath !== 'string' || binPath.trim() === '') {
+    throw new Error(`Invalid @lynx-js/rspeedy package metadata at ${manifestPath}: missing bin.rspeedy`);
+  }
+
+  return {
+    command: process.execPath,
+    args: [path.resolve(path.dirname(manifestPath), binPath)],
+  };
+}


### PR DESCRIPTION
## Summary

- resolve `@lynx-js/rspeedy` through its exported `package.json` and validated `bin.rspeedy` metadata
- invoke the resolved JavaScript bin with `process.execPath` for both `build` and `dev`
- preserve separate argument boundaries and `shell: false`, including when package or app paths contain spaces
- leave generic `runCommand` callers such as adb, Gradle, and iOS tooling shell-free

## Root cause

On Windows, npm and pnpm expose `rspeedy` through a `.cmd` batch shim. Node's `child_process.spawn()` cannot execute that shim directly with `shell: false`, so Sparkling failed with `spawn rspeedy ENOENT`.

Rather than enabling a shell for all Windows commands, this change bypasses the platform shim: it resolves Rspeedy's declared JavaScript bin from package metadata and launches it with the current Node executable. Build and dev share the same resolver, while the existing dev restart and signal lifecycle remains unchanged.

## Tests

- focused resolver and build/dev invocation tests, including package and app paths containing spaces
- config-loading precedence test for dev
- regression test that generic `runCommand` remains `shell: false`
- full `sparkling-app-cli` Jest suite: 12 suites, 71 tests
- package build
- Jest tsconfig typecheck
- diff whitespace checks
- independently reviewed compiled resolver and real resolved Rspeedy JS bin execution (`--help`)

## Residual risk

The Windows-shaped resolution and invocation behavior is covered deterministically, but the patch has not been run end-to-end on a native Windows host.

Fixes #63

This supersedes the remaining Windows Rspeedy launch portion of #73. It intentionally does not redo the ESM loader path fix, which is already present on `main`.
