### PR TITLE
fix(template): align Lynx runtime with codegen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Run release tooling unit tests
+        run: python3 -m unittest discover -s scripts/__tests__ -p '*_test.py'
+
       - name: Run TypeScript unit-test coverage
         run: pnpm coverage:ts
 

--- a/scripts/__tests__/verify_template_test.py
+++ b/scripts/__tests__/verify_template_test.py
@@ -1,4 +1,6 @@
 import importlib.util
+import re
+import tomllib
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -10,6 +12,144 @@ VERIFY_TEMPLATE = REPO_ROOT / "scripts" / "verify_template.py"
 spec = importlib.util.spec_from_file_location("verify_template", VERIFY_TEMPLATE)
 verify_template = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(verify_template)
+
+
+LYNX_SDK_COMPANION_MODULES = (
+    "lynx-jssdk",
+    "lynx-trace",
+    "lynx-service-image",
+    "lynx-service-log",
+    "lynx-service-http",
+    "lynx-service-devtool",
+    "lynx-devtool",
+)
+
+
+def maven_module_metadata(*dependencies):
+    return {
+        "variants": [
+            {
+                "name": "releaseVariantReleaseRuntimePublication",
+                "dependencies": [
+                    {
+                        "group": group,
+                        "module": module,
+                        "version": {"requires": version},
+                    }
+                    for group, module, version in dependencies
+                ],
+            },
+        ],
+    }
+
+
+class AndroidLynxAlignmentTest(unittest.TestCase):
+    def test_template_lynx_plugin_matches_version_catalog(self):
+        expected_lynx_version, _ = verify_template.template_android_lynx_versions()
+
+        ready, reason = verify_template.validate_template_android_lynx_versions()
+
+        self.assertTrue(ready, reason)
+        self.assertIn(expected_lynx_version, reason)
+
+    def test_template_host_keeps_strict_lynx_dependency_contract(self):
+        catalog = tomllib.loads(verify_template.TEMPLATE_ANDROID_VERSION_CATALOG.read_text())
+        libraries_by_module = {}
+        for alias, library in catalog["libraries"].items():
+            coordinate = library.get("module")
+            if coordinate:
+                group, module = coordinate.split(":", 1)
+            else:
+                group = library.get("group")
+                module = library.get("name")
+            if group == verify_template.LYNX_GROUP:
+                libraries_by_module[module] = (alias, library["version"]["ref"])
+
+        lynx_alias, lynx_version_ref = libraries_by_module["lynx"]
+        primjs_alias, primjs_version_ref = libraries_by_module["primjs"]
+        companion_aliases = []
+        for module in LYNX_SDK_COMPANION_MODULES:
+            alias, version_ref = libraries_by_module[module]
+            self.assertEqual(version_ref, lynx_version_ref, module)
+            companion_aliases.append(alias)
+
+        source = (verify_template.TEMPLATE_ANDROID_DIR / "app" / "build.gradle.kts").read_text()
+        source = re.sub(r"/\*.*?\*/|//[^\n]*", "", source, flags=re.DOTALL)
+        source = re.sub(r"\s+", "", source)
+        direct_pin = (
+            f"implementation(libs.{lynx_alias})"
+            f"{{version{{strictly(libs.versions.{lynx_version_ref}.get())}}"
+        )
+        constraints_index = source.index("constraints{")
+        self.assertEqual(source[:constraints_index].count(direct_pin), 1)
+
+        grouped_constraints = re.search(
+            r"listOf\((?P<aliases>libs(?:\.[A-Za-z0-9_]+)+(?:,libs(?:\.[A-Za-z0-9_]+)+)*,?)\)"
+            r"\.forEach\{(?P<variable>[A-Za-z_][A-Za-z0-9_]*)->"
+            r"implementation\((?P=variable)\)\{version\{strictly\(libs\.versions\."
+            r"(?P<version_ref>[A-Za-z_][A-Za-z0-9_]*)\.get\(\)\)",
+            source[constraints_index:],
+        )
+        self.assertIsNotNone(grouped_constraints)
+        self.assertEqual(
+            set(grouped_constraints.group("aliases").strip(",").split(",")),
+            {"libs." + re.sub(r"[-_.]+", ".", alias) for alias in companion_aliases},
+        )
+        self.assertEqual(grouped_constraints.group("version_ref"), lynx_version_ref)
+
+        primjs_constraint = (
+            f"implementation(libs.{primjs_alias})"
+            f"{{version{{strictly(libs.versions.{primjs_version_ref}.get())}}"
+        )
+        self.assertEqual(source[constraints_index:].count(primjs_constraint), 1)
+
+    def test_maven_metadata_accepts_coherent_lynx_versions(self):
+        metadata = {
+            "com/tiktok/sparkling/sparkling": maven_module_metadata(
+                ("org.lynxsdk.lynx", "lynx", "3.9.0"),
+                ("org.lynxsdk.lynx", "lynx-jssdk", "3.9.0"),
+                ("org.lynxsdk.lynx", "lynx-trace", "3.9.0"),
+                ("org.lynxsdk.lynx", "primjs", "3.8.0-alpha.6"),
+                ("org.lynxsdk.lynx", "lynx-service-image", "3.9.0"),
+                ("org.lynxsdk.lynx", "lynx-service-http", "3.9.0"),
+            ),
+            "com/tiktok/sparkling/sparkling-method": maven_module_metadata(
+                ("org.lynxsdk.lynx", "lynx", "3.9.0"),
+            ),
+            "com/tiktok/sparkling/sparkling-debug-tool": maven_module_metadata(
+                ("org.lynxsdk.lynx", "lynx", "3.9.0"),
+                ("org.lynxsdk.lynx", "lynx-service-log", "3.9.0"),
+                ("org.lynxsdk.lynx", "lynx-service-devtool", "3.9.0"),
+                ("org.lynxsdk.lynx", "lynx-devtool", "3.9.0"),
+                ("org.lynxsdk.lynx", "debug-router", "0.0.18"),
+            ),
+        }
+
+        ready, reason = verify_template.validate_maven_lynx_versions(
+            metadata,
+            "3.9.0",
+            "3.8.0-alpha.6",
+        )
+
+        self.assertTrue(ready, reason)
+
+    def test_maven_metadata_rejects_stale_lynx_versions(self):
+        metadata = {
+            "com/tiktok/sparkling/sparkling": maven_module_metadata(
+                ("org.lynxsdk.lynx", "lynx", "3.6.0"),
+                ("org.lynxsdk.lynx", "primjs", "3.6.1"),
+            ),
+        }
+
+        ready, reason = verify_template.validate_maven_lynx_versions(
+            metadata,
+            "3.9.0",
+            "3.8.0-alpha.6",
+        )
+
+        self.assertFalse(ready)
+        self.assertIn("org.lynxsdk.lynx:lynx:3.6.0", reason)
+        self.assertIn("org.lynxsdk.lynx:primjs:3.6.1", reason)
 
 
 class CocoaPodsCdnTest(unittest.TestCase):

--- a/scripts/verify_template.py
+++ b/scripts/verify_template.py
@@ -22,20 +22,33 @@ import argparse
 import hashlib
 import json
 import os
+import re
 import shutil
 import subprocess
 import time
+import tomllib
 import urllib.request
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 TEMPLATE_DIR = REPO_ROOT / "template" / "sparkling-app-template"
+TEMPLATE_ANDROID_DIR = TEMPLATE_DIR / "android"
+TEMPLATE_ANDROID_VERSION_CATALOG = TEMPLATE_ANDROID_DIR / "gradle" / "libs.versions.toml"
+PLAYGROUND_ANDROID_DIR = REPO_ROOT / "packages" / "playground" / "android"
+PLAYGROUND_ANDROID_VERSION_CATALOG = PLAYGROUND_ANDROID_DIR / "gradle" / "libs.versions.toml"
 CLI_DIR = REPO_ROOT / "packages" / "create-sparkling-app"
 CLI_ENTRY = CLI_DIR / "dist" / "index.js"
 IOS_PODS_CONFIG = REPO_ROOT / "scripts" / "ios_pods.json"
 COCOAPODS_USER_AGENT = "CocoaPods/1.16.2"
 COCOAPODS_CDN_ROOT = "https://cdn.cocoapods.org"
 COCOAPODS_CDN_BASE = f"{COCOAPODS_CDN_ROOT}/Specs"
+MAVEN_CENTRAL_ROOT = "https://repo1.maven.org/maven2"
+LYNX_GROUP = "org.lynxsdk.lynx"
+LYNX_PLUGIN_COORDINATE_PATTERN = re.compile(
+    r'org\.lynxsdk\.lynx:lynx-library-plugin:([^"]+)'
+)
+INDEPENDENT_LYNX_MODULES = {"debug-router", "v8so"}
+PRIMJS_MODULES = {"primjs", "primjsWasm"}
 
 # npm packages the scaffolded project installs at the release version.
 NPM_PACKAGES = [
@@ -116,6 +129,117 @@ def read_url(url):
 
 def read_json_url(url):
     return json.loads(read_url(url))
+
+
+def read_maven_json_url(url):
+    with urllib.request.urlopen(url, timeout=30) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def android_lynx_versions(path):
+    catalog = tomllib.loads(path.read_text())
+    versions = catalog["versions"]
+    return versions["lynxSdk"], versions["primjs"]
+
+
+def template_android_lynx_versions():
+    return android_lynx_versions(TEMPLATE_ANDROID_VERSION_CATALOG)
+
+
+def validate_template_android_lynx_versions():
+    lynx_version, primjs_version = template_android_lynx_versions()
+    mismatches = []
+    published_lynx_version, published_primjs_version = android_lynx_versions(
+        PLAYGROUND_ANDROID_VERSION_CATALOG
+    )
+    if (published_lynx_version, published_primjs_version) != (lynx_version, primjs_version):
+        mismatches.append(
+            f"{PLAYGROUND_ANDROID_VERSION_CATALOG.relative_to(REPO_ROOT)}: "
+            f"expected Lynx {lynx_version} / PrimJS {primjs_version}, "
+            f"got Lynx {published_lynx_version} / PrimJS {published_primjs_version}"
+        )
+    for path in [
+        TEMPLATE_ANDROID_DIR / "build.gradle.kts",
+        TEMPLATE_ANDROID_DIR / "settings.gradle.kts",
+        PLAYGROUND_ANDROID_DIR / "build.gradle.kts",
+        PLAYGROUND_ANDROID_DIR / "settings.gradle.kts",
+    ]:
+        matches = LYNX_PLUGIN_COORDINATE_PATTERN.findall(path.read_text())
+        if matches != [lynx_version]:
+            actual = ", ".join(matches) if matches else "<missing>"
+            mismatches.append(f"{path.relative_to(REPO_ROOT)}: expected {lynx_version}, got {actual}")
+    if mismatches:
+        return False, "Lynx library plugin/catalog mismatch: " + "; ".join(mismatches)
+    return True, f"Android publication, template, and Lynx library plugin use {lynx_version}"
+
+
+def maven_module_metadata_url(artifact, version):
+    name = artifact.rsplit("/", 1)[1]
+    return f"{MAVEN_CENTRAL_ROOT}/{artifact}/{version}/{name}-{version}.module"
+
+
+def dependency_version(dependency):
+    version = dependency.get("version", {})
+    for key in ("strictly", "requires", "prefers"):
+        if version.get(key):
+            return version[key]
+    return None
+
+
+def validate_maven_lynx_versions(module_metadata, lynx_version, primjs_version):
+    mismatches = []
+    for artifact, metadata in module_metadata.items():
+        seen = set()
+        for variant in metadata.get("variants", []):
+            dependencies = variant.get("dependencies", []) + variant.get("dependencyConstraints", [])
+            for dependency in dependencies:
+                if dependency.get("group") != LYNX_GROUP:
+                    continue
+                module = dependency.get("module")
+                actual = dependency_version(dependency)
+                entry = module, actual
+                if entry in seen:
+                    continue
+                seen.add(entry)
+                if module in INDEPENDENT_LYNX_MODULES:
+                    continue
+                expected = primjs_version if module in PRIMJS_MODULES else lynx_version
+                if actual != expected:
+                    mismatches.append(
+                        f"{artifact} publishes {LYNX_GROUP}:{module}:{actual or '<missing>'}; "
+                        f"template expects {expected}"
+                    )
+        if not seen:
+            mismatches.append(f"{artifact} publishes no Lynx dependency metadata")
+    if mismatches:
+        return False, "; ".join(mismatches)
+    return True, f"published Sparkling metadata matches Lynx {lynx_version} / PrimJS {primjs_version}"
+
+
+def verify_android_lynx_alignment(version, fetch_json=read_maven_json_url):
+    section("Verifying Android Lynx dependency alignment")
+    template_ready, template_reason = validate_template_android_lynx_versions()
+    if not template_ready:
+        raise SystemExit(f"::error::{template_reason}")
+    log(f"  template ok: {template_reason}")
+
+    lynx_version, primjs_version = template_android_lynx_versions()
+    module_metadata = {}
+    for artifact in MAVEN_ARTIFACTS:
+        url = maven_module_metadata_url(artifact, version)
+        try:
+            module_metadata[artifact] = fetch_json(url)
+        except Exception as err:
+            raise SystemExit(f"::error::Maven module metadata unavailable at {url}: {err}") from err
+
+    metadata_ready, metadata_reason = validate_maven_lynx_versions(
+        module_metadata,
+        lynx_version,
+        primjs_version,
+    )
+    if not metadata_ready:
+        raise SystemExit(f"::error::Android Lynx dependency mismatch: {metadata_reason}")
+    log(f"  maven ok: {metadata_reason}")
 
 
 def cocoapods_cdn_shard(pod):
@@ -207,10 +331,11 @@ def wait_for_maven(version, attempts=90, delay=20):
     missing = []
     for artifact in MAVEN_ARTIFACTS:
         base = artifact.rsplit("/", 1)[1]
-        url = f"https://repo1.maven.org/maven2/{artifact}/{version}/{base}-{version}.pom"
+        pom_url = f"{MAVEN_CENTRAL_ROOT}/{artifact}/{version}/{base}-{version}.pom"
+        module_url = maven_module_metadata_url(artifact, version)
         found = False
         for i in range(1, attempts + 1):
-            if http_ok(url):
+            if http_ok(pom_url) and http_ok(module_url):
                 log(f"  maven ok: {artifact.replace('/', '.')}:{version} (after {i} check(s))")
                 found = True
                 break
@@ -375,6 +500,7 @@ def verify_ios(version, workspace_dir, podfile_lock_out):
 def verify_android(version, workspace_dir):
     wait_for_npm(version)
     wait_for_maven(version)
+    verify_android_lynx_alignment(version)
     project = scaffold(workspace_dir)
 
     def attempt():

--- a/template/sparkling-app-template/android/app/build.gradle.kts
+++ b/template/sparkling-app-template/android/app/build.gradle.kts
@@ -75,6 +75,37 @@ android {
 }
 
 dependencies {
+    implementation(libs.lynx) {
+        version {
+            strictly(libs.versions.lynxSdk.get())
+        }
+        because("Lynx library codegen must compile against its matching runtime")
+    }
+    constraints {
+        listOf(
+            libs.lynx.jssdk,
+            libs.lynx.trace,
+            libs.lynx.service.image,
+            libs.lynx.service.log,
+            libs.lynx.service.http,
+            libs.lynx.service.devtool,
+            libs.lynx.devtool,
+        ).forEach { lynxDependency ->
+            implementation(lynxDependency) {
+                version {
+                    strictly(libs.versions.lynxSdk.get())
+                }
+                because("Keep the template on one Lynx SDK version")
+            }
+        }
+        implementation(libs.primjs) {
+            version {
+                strictly(libs.versions.primjs.get())
+            }
+            because("Keep PrimJS aligned with the template Lynx runtime")
+        }
+    }
+
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     testImplementation(libs.junit)


### PR DESCRIPTION
## Summary

- align the Android app template's runtime dependencies with the Lynx 3.9 codegen/plugin contract
- strictly constrain transitive Lynx modules and PrimJS so older Sparkling publication metadata cannot silently downgrade the generated app
- verify published Gradle module metadata during Android template release validation
- add a lightweight CI guard for template/plugin/catalog/runtime drift

## Why

The source template used the Lynx 3.9 library plugin, while the checked-in Sparkling Maven version could resolve Lynx 3.6 transitively. That generated `LynxAutolinkGenerated.java` against APIs absent from the resolved runtime and broke Android template builds.

## Validation

- `python3 -m unittest discover -s scripts/__tests__ -p '*_test.py'` — 12 passed
- `pnpm --filter sparkling-app-template test` — 1 passed
- Android incremental `:app:assembleRelease` — passed
- resolved `releaseRuntimeClasspath` — Lynx 3.9.0, PrimJS 3.8.0-alpha.6
- Sandbox clean cold launch — `Sparkling Starter` home rendered
- Sandbox navigation smoke — `Open second page` reached `This is the second page`
- release APKs retain ABI splits and shrinking: arm64-v8a 14 MB, armeabi-v7a 8.6 MB

Fixes #112
Related to #61
